### PR TITLE
Api reform

### DIFF
--- a/addon/components/animated-container.js
+++ b/addon/components/animated-container.js
@@ -1,7 +1,7 @@
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
-import Resize from '../motions/resize';
+import { Resize } from '../motions/resize';
 import { task } from '../ember-scheduler';
 import Sprite from '../sprite';
 import { emptyBounds } from '../bounds';

--- a/addon/debug.js
+++ b/addon/debug.js
@@ -1,0 +1,17 @@
+import { DEBUG } from '@glimmer/env';
+
+let printSprites;
+
+if (DEBUG) {
+  printSprites = function printSprites(context, label){
+    let prefix = label ? label + ' ' : '';
+    /* eslint no-console:0 */
+    console.log(prefix + ['inserted', 'kept', 'removed', 'sent', 'received'].map(type => {
+      return type + '=' + context[`_${type}Sprites`].map(s => s.owner.id).join(',')
+    }).join(" | "));
+  }
+} else {
+  printSprites = function(){};
+}
+
+export { printSprites };

--- a/addon/motion.js
+++ b/addon/motion.js
@@ -1,3 +1,4 @@
+import { spawnChild } from './scheduler';
 import {
   rAF,
   Promise,
@@ -28,6 +29,22 @@ export default class Motion {
     });
   }
 
+  run() {
+    let context = this.sprite._transitionContext;
+    if (this.duration == null) {
+      this.duration = context.duration;
+    }
+    let self = this;
+    return spawnChild(function *() {
+      context.onMotionStart(self.sprite);
+      try {
+        yield * self._run();
+      } finally {
+        context.onMotionEnd(self.sprite);
+      }
+    });
+  }
+
   // --- Begin Hooks you should Implement ---
 
   // Here you can inspect the other motions on this element that have
@@ -48,8 +65,6 @@ export default class Motion {
   // --- Begin private methods ---
 
 
-  // this is private because the public way to run a motion is
-  // TransitionContext#animate.
   * _run() {
     try {
       let others = this._motionList.filter(m => m !== this);

--- a/addon/motions/follow.js
+++ b/addon/motions/follow.js
@@ -2,9 +2,13 @@ import Move from './move';
 import Tween from '../tween';
 import { rAF } from '../concurrency-helpers';
 
+export default function follow(sprite, opts) {
+  return new Follow(sprite, opts).run();
+}
+
 // Because we inherit from Move, if we are interrupted by a Move the
 // new Move will still preserve our momentum.
-export default class Follow extends Move {
+export class Follow extends Move {
   constructor(sprite, opts) {
     super(sprite, opts);
     if (!(this.opts.source instanceof Move)) {

--- a/addon/motions/follow.js
+++ b/addon/motions/follow.js
@@ -1,4 +1,4 @@
-import Move from './move';
+import { Move } from './move';
 import Tween from '../tween';
 import { rAF } from '../concurrency-helpers';
 

--- a/addon/motions/move.js
+++ b/addon/motions/move.js
@@ -2,12 +2,11 @@ import Motion from '../motion';
 import Tween from '../tween';
 import { rAF } from '../concurrency-helpers';
 
-// TODO make this the default export
-export function move(sprite, opts) {
+export default function move(sprite, opts) {
   return new Move(sprite, opts).run();
 }
 
-export default class Move extends Motion {
+export class Move extends Motion {
   constructor(sprite, opts) {
     super(sprite, opts);
     this.prior = null;

--- a/addon/motions/move.js
+++ b/addon/motions/move.js
@@ -2,6 +2,11 @@ import Motion from '../motion';
 import Tween from '../tween';
 import { rAF } from '../concurrency-helpers';
 
+// TODO make this the default export
+export function move(sprite, opts) {
+  return new Move(sprite, opts).run();
+}
+
 export default class Move extends Motion {
   constructor(sprite, opts) {
     super(sprite, opts);
@@ -99,6 +104,11 @@ export default class Move extends Motion {
 // is no fun.
 function fuzzyZero(number) {
   return Math.abs(number) < 0.00001;
+}
+
+
+export function continuePrior(sprite, opts) {
+  return new ContinuePrior(sprite, opts).run();
 }
 
 export class ContinuePrior extends Move {

--- a/addon/motions/opacity.js
+++ b/addon/motions/opacity.js
@@ -4,6 +4,11 @@ import Tween from '../tween';
 import { rAF } from '../concurrency-helpers';
 import linear from '../easings/linear';
 
+// TODO make this default
+export function opacity(sprite, opts) {
+  return new Opacity(sprite, opts).run();
+}
+
 export default class Opacity extends Motion {
   constructor(sprite, opts) {
     super(sprite, opts);

--- a/addon/motions/opacity.js
+++ b/addon/motions/opacity.js
@@ -4,12 +4,11 @@ import Tween from '../tween';
 import { rAF } from '../concurrency-helpers';
 import linear from '../easings/linear';
 
-// TODO make this default
-export function opacity(sprite, opts) {
+export default function opacity(sprite, opts) {
   return new Opacity(sprite, opts).run();
 }
 
-export default class Opacity extends Motion {
+export class Opacity extends Motion {
   constructor(sprite, opts) {
     super(sprite, opts);
     this.prior = null;

--- a/addon/motions/resize.js
+++ b/addon/motions/resize.js
@@ -2,7 +2,11 @@ import Motion from '../motion';
 import Tween from '../tween';
 import { rAF } from '../concurrency-helpers';
 
-export default class Resize extends Motion {
+export default function resize(sprite, opts) {
+  return new Resize(sprite, opts).run();
+}
+
+export class Resize extends Motion {
   constructor(sprite, opts) {
     super(sprite, opts);
     this.prior = null;

--- a/addon/motions/scale.js
+++ b/addon/motions/scale.js
@@ -2,11 +2,11 @@ import Motion from '../motion';
 import Tween from '../tween';
 import { rAF } from '../concurrency-helpers';
 
-export function scale(sprite, opts) {
+export default function scale(sprite, opts) {
   return new Scale(sprite, opts).run();
 }
 
-export default class Scale extends Motion {
+export class Scale extends Motion {
   constructor(sprite, opts) {
     super(sprite, opts);
     this.widthTween = null;

--- a/addon/motions/scale.js
+++ b/addon/motions/scale.js
@@ -2,6 +2,10 @@ import Motion from '../motion';
 import Tween from '../tween';
 import { rAF } from '../concurrency-helpers';
 
+export function scale(sprite, opts) {
+  return new Scale(sprite, opts).run();
+}
+
 export default class Scale extends Motion {
   constructor(sprite, opts) {
     super(sprite, opts);

--- a/addon/sprite.js
+++ b/addon/sprite.js
@@ -76,6 +76,11 @@ export default class Sprite {
     this._transform = null;
     this._offsetSprite = offsetSprite;
 
+    // This gets set by TransitionContext when a sprite is used within
+    // a TransitionContext. It's a convenience that allows users to
+    // just pass Sprites to Motions without also passing the context.
+    this._transitionContext = null;
+
     let predecessor = inFlight.get(element);
     if (predecessor && lockMode) {
       // When we finish, we want to be able to set the style back to

--- a/addon/transition-context.js
+++ b/addon/transition-context.js
@@ -1,8 +1,4 @@
-import { DEBUG } from '@glimmer/env';
-import {
-  spawnChild,
-  childrenSettled
-} from './scheduler';
+import {  childrenSettled } from './scheduler';
 
 export default class TransitionContext {
   constructor(duration, insertedSprites, keptSprites, removedSprites, sentSprites, receivedSprites) {
@@ -39,6 +35,10 @@ export default class TransitionContext {
   }
 
   _prepareSprites(sprites) {
+    // Link them up, so that users can conveniently pass sprites
+    // around to Motions without also passing the transition context.
+    sprites.forEach(sprite => sprite._transitionContext = this);
+
     if (!this.prepareSprite) {
       return sprites;
     }
@@ -51,34 +51,8 @@ export default class TransitionContext {
     });
   }
 
-  animate(motion) {
-    if (motion.duration == null) {
-      motion.duration = this.duration;
-    }
-    let self = this;
-    return spawnChild(function *() {
-      self.onMotionStart(motion.sprite);
-      try {
-        yield * motion._run();
-      } finally {
-        self.onMotionEnd(motion.sprite);
-      }
-    });
-  }
   *_runToCompletion(transition) {
-    yield * transition.call(this);
+    yield * transition(this);
     yield childrenSettled();
   }
-}
-
-if (DEBUG) {
-  TransitionContext.prototype.printSprites = function (label){
-    let prefix = label ? label + ' ' : '';
-    /* eslint no-console:0 */
-    console.log(prefix + ['inserted', 'kept', 'removed', 'sent', 'received'].map(type => {
-      return type + '=' + this[`_${type}Sprites`].map(s => s.owner.id).join(',')
-    }).join(" | "));
-  };
-} else {
-  TransitionContext.prototype.printSprites = function(){};
 }

--- a/addon/transitions/move-over.js
+++ b/addon/transitions/move-over.js
@@ -1,21 +1,10 @@
 import Move from '../motions/move';
-import Follow from '../motions/follow';
+import follow from '../motions/follow';
 
-export function toLeft() {
-  return moveOver.call(this, 'x', -1);
-}
-
-export function toRight() {
-  return moveOver.call(this, 'x', 1);
-}
-
-export function toUp() {
-  return moveOver.call(this, 'y', -1);
-}
-
-export function toDown() {
-  return moveOver.call(this, 'y', 1);
-}
+export const toLeft = moveOver.bind(null, 'x', -1);
+export const toRight = moveOver.bind(null, 'x', 1);
+export const toUp = moveOver.bind(null, 'y', -1);
+export const toDown = moveOver.bind(null, 'y', 1);
 
 function normalize(dimension, direction) {
   let position;
@@ -48,7 +37,7 @@ function normalize(dimension, direction) {
   return { position, size, startTranslatedBy, endTranslatedBy };
 }
 
-export default function * moveOver(dimension, direction) {
+export function * moveOver(dimension, direction, context) {
   let {
     position,
     size,
@@ -57,15 +46,15 @@ export default function * moveOver(dimension, direction) {
   } = normalize(dimension, direction);
 
   let viewport;
-  if (this.insertedSprites.length) {
-    viewport = this.insertedSprites[0].finalBounds;
-  } else if (this.keptSprites.length) {
-    viewport = this.keptSprites[0].finalBounds;
+  if (context.insertedSprites.length) {
+    viewport = context.insertedSprites[0].finalBounds;
+  } else if (context.keptSprites.length) {
+    viewport = context.keptSprites[0].finalBounds;
   } else {
     throw new Error("Unimplemented");
   }
 
-  if (this.insertedSprites.length) {
+  if (context.insertedSprites.length) {
 
     // Offset is how far out of place we're going to start the inserted sprite.
     let offset = 0;
@@ -73,7 +62,7 @@ export default function * moveOver(dimension, direction) {
     // if any leaving sprites still hang outside the viewport to the
     // left, they add to our offset because the new sprite will be to
     // their left.
-    this.removedSprites.forEach(sprite => {
+    context.removedSprites.forEach(sprite => {
       let o = position(viewport) - position(sprite.initialBounds);
       if (o > offset) {
         offset = o;
@@ -83,26 +72,26 @@ export default function * moveOver(dimension, direction) {
     // the new sprite's own width adds to our offset because we want its
     // right edge (not left edge) to start touching the leftmost leaving
     // sprite (or viewport if no leaving sprites)
-    offset += size(this.insertedSprites[0].finalBounds);
+    offset += size(context.insertedSprites[0].finalBounds);
 
-    startTranslatedBy(this.insertedSprites[0], -offset);
+    startTranslatedBy(context.insertedSprites[0], -offset);
 
-    if (this.removedSprites.length > 0) {
-      endTranslatedBy(this.removedSprites[0], offset);
-      let move = new Move(this.removedSprites[0]);
-      this.animate(move);
-      for (let i = 1; i < this.removedSprites.length; i++) {
-        this.animate(new Follow(this.removedSprites[i], { source: move }));
+    if (context.removedSprites.length > 0) {
+      endTranslatedBy(context.removedSprites[0], offset);
+      let move = new Move(context.removedSprites[0]);
+      move.run();
+      for (let i = 1; i < context.removedSprites.length; i++) {
+        follow(context.removedSprites[i], { source: move });
       }
-      this.animate(new Follow(this.insertedSprites[0], { source: move }));
+      follow(context.insertedSprites[0], { source: move });
     } else {
-      this.animate(new Move(this.insertedSprites[0]));
+      new Move(context.insertedSprites[0]).run();
     }
-  } else if (this.keptSprites.length) {
-    let move = new Move(this.keptSprites[0]);
-    this.animate(move);
-    this.removedSprites.forEach(sprite => {
-      this.animate(new Follow(sprite, { source: move }));
+  } else if (context.keptSprites.length) {
+    let move = new Move(context.keptSprites[0]);
+    move.run();
+    context.removedSprites.forEach(sprite => {
+      follow(sprite, { source: move });
     });
   } else {
     throw new Error("Unimplemented2");

--- a/addon/transitions/move-over.js
+++ b/addon/transitions/move-over.js
@@ -1,4 +1,4 @@
-import Move from '../motions/move';
+import { Move } from '../motions/move';
 import follow from '../motions/follow';
 
 export const toLeft = moveOver.bind(null, 'x', -1);
@@ -37,7 +37,7 @@ function normalize(dimension, direction) {
   return { position, size, startTranslatedBy, endTranslatedBy };
 }
 
-export function * moveOver(dimension, direction, context) {
+export default function * moveOver(dimension, direction, context) {
   let {
     position,
     size,

--- a/tests/dummy/app/components/animated-text.js
+++ b/tests/dummy/app/components/animated-text.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { move } from 'ember-animated/motions/move';
+import move from 'ember-animated/motions/move';
 
 export default Component.extend({
   tagName: '',

--- a/tests/dummy/app/components/animated-text.js
+++ b/tests/dummy/app/components/animated-text.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import Move from 'ember-animated/motions/move';
+import { move } from 'ember-animated/motions/move';
 
 export default Component.extend({
   tagName: '',
@@ -8,6 +8,6 @@ export default Component.extend({
   positionalParams: ['text']
 });
 
-function * transition() {
-  this.sentSprites.forEach(sprite => this.animate(new Move(sprite)));
+function * transition({ sentSprites }) {
+  sentSprites.forEach(move);
 }

--- a/tests/dummy/app/components/each-example.js
+++ b/tests/dummy/app/components/each-example.js
@@ -2,7 +2,7 @@ import { A } from '@ember/array';
 import { computed, set } from '@ember/object';
 import Component from '@ember/component';
 import { task, timeout } from 'ember-animated/ember-scheduler';
-import { move } from 'ember-animated/motions/move';
+import move from 'ember-animated/motions/move';
 
 export default Component.extend({
   rules,

--- a/tests/dummy/app/components/each-example.js
+++ b/tests/dummy/app/components/each-example.js
@@ -2,7 +2,7 @@ import { A } from '@ember/array';
 import { computed, set } from '@ember/object';
 import Component from '@ember/component';
 import { task, timeout } from 'ember-animated/ember-scheduler';
-import Move from 'ember-animated/motions/move';
+import { move } from 'ember-animated/motions/move';
 
 export default Component.extend({
   rules,
@@ -81,40 +81,24 @@ function random() {
   return Math.random() - 0.5;
 }
 
-function * first() {
-  this.insertedSprites.forEach(sprite => {
-    sprite.reveal();
-  });
-
-  this.keptSprites.forEach(sprite => {
-    this.animate(new Move(sprite));
-  });
-}
-
-function * subsequent() {
-  this.insertedSprites.forEach(sprite => {
-    sprite.startAtPixel({ x: window.outerWidth });
-    this.animate(new Move(sprite));
-  });
-
-  this.keptSprites.forEach(sprite => {
-    this.animate(new Move(sprite));
-  });
-
-  this.removedSprites.forEach(sprite => {
-    // the 0.8 here is purely so I can easily see that the elements
-    // are being properly removed immediately after they get far
-    // enough
-    sprite.endAtPixel({ x: window.outerWidth * 0.8 });
-    this.animate(new Move(sprite));
-  });
-
-}
 
 function rules(firstTime) {
-  if (firstTime) {
-    return first;
-  } else {
-    return subsequent;
+  if (!firstTime) {
+    return function * ({ insertedSprites, keptSprites, removedSprites }) {
+      insertedSprites.forEach(sprite => {
+        sprite.startAtPixel({ x: window.outerWidth });
+        move(sprite);
+      });
+
+      keptSprites.forEach(move);
+
+      removedSprites.forEach(sprite => {
+        // the 0.8 here is purely so I can easily see that the elements
+        // are being properly removed immediately after they get far
+        // enough
+        sprite.endAtPixel({ x: window.outerWidth * 0.8 });
+        move(sprite);
+      });
+    }
   }
 }

--- a/tests/dummy/app/components/swapping-lists-example.js
+++ b/tests/dummy/app/components/swapping-lists-example.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import Move from 'ember-animated/motions/move';
+import { move } from 'ember-animated/motions/move';
 import { computed } from '@ember/object';
 
 export default Component.extend({
@@ -47,17 +47,17 @@ function makeRandomList() {
 }
 
 
-function * transition() {
-  this.receivedSprites.forEach(s => this.animate(new Move(s)));
+function * transition({ receivedSprites, insertedSprites }) {
+  receivedSprites.forEach(move);
   // without this, they won't reveal until the end of the whole
   // transition
-  this.insertedSprites.forEach(s => s.reveal());
+  insertedSprites.forEach(s => s.reveal());
 }
 
-function * altTransition() {
-  this.receivedSprites.forEach(sprite => sprite.moveToFinalPosition());
-  this.sentSprites.forEach(s => this.animate(new Move(s)));
+function * altTransition({ receivedSprites, sentSprites, insertedSprites }) {
+  receivedSprites.forEach(sprite => sprite.moveToFinalPosition());
+  sentSprites.forEach(move);
   // without this, they won't reveal until the end of the whole
   // transition
-  this.insertedSprites.forEach(s => s.reveal());
+  insertedSprites.forEach(s => s.reveal());
 }

--- a/tests/dummy/app/components/swapping-lists-example.js
+++ b/tests/dummy/app/components/swapping-lists-example.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { move } from 'ember-animated/motions/move';
+import move from 'ember-animated/motions/move';
 import { computed } from '@ember/object';
 
 export default Component.extend({

--- a/tests/dummy/app/components/two-lists-example.js
+++ b/tests/dummy/app/components/two-lists-example.js
@@ -1,7 +1,7 @@
 import { later } from '@ember/runloop';
 import { computed } from '@ember/object';
 import Component from '@ember/component';
-import Move from 'ember-animated/motions/move';
+import { move } from 'ember-animated/motions/move';
 
 export default Component.extend({
   bounceBack: false,
@@ -59,14 +59,14 @@ function makeRandomItem() {
   return { id: Math.round(Math.random()*1000) };
 }
 
-function * transition() {
+function * transition({ keptSprites, sentSprites, receivedSprites }) {
   // The parts of each list that haven't changed moves to accomodate
   // inserted and removed peers
-  this.keptSprites.forEach(sprite => this.animate(new Move(sprite)));
+  keptSprites.forEach(move);
 
   // Elements that are leaving our list get animated into their new
   // positions in the other list.
-  this.sentSprites.forEach(sprite => this.animate(new Move(sprite)));
+  sentSprites.forEach(move);
 
   // Elements that are arriving in our list don't animate (the other
   // list's sentSprites will animate instead). But we want them to
@@ -76,5 +76,5 @@ function * transition() {
   // Without this, they would get the default behavior for
   // receivedSprites, which is starting at the same location as the
   // corresponding element in the other list.
-  this.receivedSprites.forEach(sprite => sprite.moveToFinalPosition());
+  receivedSprites.forEach(sprite => sprite.moveToFinalPosition());
 }

--- a/tests/dummy/app/components/two-lists-example.js
+++ b/tests/dummy/app/components/two-lists-example.js
@@ -1,7 +1,7 @@
 import { later } from '@ember/runloop';
 import { computed } from '@ember/object';
 import Component from '@ember/component';
-import { move } from 'ember-animated/motions/move';
+import move from 'ember-animated/motions/move';
 
 export default Component.extend({
   bounceBack: false,

--- a/tests/dummy/app/controllers/direct-style.js
+++ b/tests/dummy/app/controllers/direct-style.js
@@ -2,7 +2,7 @@ import { A } from '@ember/array';
 import Controller from '@ember/controller';
 import { htmlSafe } from '@ember/string';
 import EmberObject, { computed } from '@ember/object';
-import { move } from 'ember-animated/motions/move';
+import move from 'ember-animated/motions/move';
 
 let Item = EmberObject.extend({
   style: computed('x', 'y', function() {

--- a/tests/dummy/app/controllers/direct-style.js
+++ b/tests/dummy/app/controllers/direct-style.js
@@ -2,7 +2,7 @@ import { A } from '@ember/array';
 import Controller from '@ember/controller';
 import { htmlSafe } from '@ember/string';
 import EmberObject, { computed } from '@ember/object';
-import Move from 'ember-animated/motions/move';
+import { move } from 'ember-animated/motions/move';
 
 let Item = EmberObject.extend({
   style: computed('x', 'y', function() {
@@ -33,6 +33,6 @@ function somewhere() {
   return Math.random() * 300;
 }
 
-function * transition() {
-  this.keptSprites.forEach(s => this.animate(new Move(s)));
+function * transition({ keptSprites }) {
+  keptSprites.forEach(move);
 }

--- a/tests/dummy/app/controllers/here-there.js
+++ b/tests/dummy/app/controllers/here-there.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { computed } from "@ember/object"
 import { not } from "@ember/object/computed"
-import { move } from 'ember-animated/motions/move';
+import move from 'ember-animated/motions/move';
 import { printSprites } from 'ember-animated/debug';
 
 export default Controller.extend({

--- a/tests/dummy/app/controllers/here-there.js
+++ b/tests/dummy/app/controllers/here-there.js
@@ -1,7 +1,8 @@
 import Controller from '@ember/controller';
 import { computed } from "@ember/object"
 import { not } from "@ember/object/computed"
-import Move from 'ember-animated/motions/move';
+import { move } from 'ember-animated/motions/move';
+import { printSprites } from 'ember-animated/debug';
 
 export default Controller.extend({
   showLeft: true,
@@ -19,7 +20,7 @@ export default Controller.extend({
   }
 });
 
-function * transition() {
-  this.printSprites();
-  this.receivedSprites.forEach(sprite => this.animate(new Move(sprite)));
+function * transition({ receivedSprites }) {
+  printSprites(arguments[0]);
+  receivedSprites.forEach(move);
 }

--- a/tests/dummy/app/controllers/hero/detail.js
+++ b/tests/dummy/app/controllers/hero/detail.js
@@ -1,30 +1,30 @@
 import Controller from '@ember/controller';
-import Move, { ContinuePrior } from 'ember-animated/motions/move';
-import Scale from 'ember-animated/motions/scale';
-import Opacity from 'ember-animated/motions/opacity';
+import { move, continuePrior } from 'ember-animated/motions/move';
+import { scale } from 'ember-animated/motions/scale';
+import { opacity } from 'ember-animated/motions/opacity';
 
-function * transition() {
-  this.receivedSprites.forEach(sprite => {
+function * transition({ receivedSprites, sentSprites, removedSprites }) {
+  receivedSprites.forEach(sprite => {
     sprite.scale(sprite.initialBounds.width / sprite.finalBounds.width, sprite.initialBounds.height / sprite.finalBounds.height);
     sprite.applyStyles({
       'z-index': 1
     });
-    this.animate(new Move(sprite));
-    this.animate(new Scale(sprite));
+    move(sprite);
+    scale(sprite);
   });
 
-  this.sentSprites.forEach(sprite => {
+  sentSprites.forEach(sprite => {
     sprite.applyStyles({
       'z-index': 1
     });
-    this.animate(new Move(sprite));
-    this.animate(new Scale(sprite));
+    move(sprite);
+    scale(sprite);
   });
 
-  this.removedSprites.forEach(sprite => {
+  removedSprites.forEach(sprite => {
     sprite.endTranslatedBy(0, 0);
-    this.animate(new ContinuePrior(sprite));
-    this.animate(new Opacity(sprite, { to: 0 }));
+    continuePrior(sprite);
+    opacity(sprite, { to: 0 });
   });
 }
 

--- a/tests/dummy/app/controllers/hero/detail.js
+++ b/tests/dummy/app/controllers/hero/detail.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
-import { move, continuePrior } from 'ember-animated/motions/move';
-import { scale } from 'ember-animated/motions/scale';
-import { opacity } from 'ember-animated/motions/opacity';
+import move, { continuePrior } from 'ember-animated/motions/move';
+import scale from 'ember-animated/motions/scale';
+import opacity from 'ember-animated/motions/opacity';
 
 function * transition({ receivedSprites, sentSprites, removedSprites }) {
   receivedSprites.forEach(sprite => {

--- a/tests/dummy/app/controllers/hero/index.js
+++ b/tests/dummy/app/controllers/hero/index.js
@@ -1,17 +1,17 @@
 import Controller from '@ember/controller';
-import Opacity from 'ember-animated/motions/opacity';
+import { opacity } from 'ember-animated/motions/opacity';
 
-function * transition() {
-  this.insertedSprites.forEach(sprite => {
-    this.animate(new Opacity(sprite, { from: 0, to: 1 }));
+function * transition({ insertedSprites, receivedSprites, removedSprites }) {
+  insertedSprites.forEach(sprite => {
+    opacity(sprite, { from: 0, to: 1 });
   });
 
-  this.receivedSprites.forEach(sprite => {
-    this.animate(new Opacity(sprite, { to: 1 }));
+  receivedSprites.forEach(sprite => {
+    opacity(sprite, { to: 1 });
   });
 
-  this.removedSprites.forEach(sprite => {
-    this.animate(new Opacity(sprite, { to: 0 }));
+  removedSprites.forEach(sprite => {
+    opacity(sprite, { to: 0 });
   });
 }
 

--- a/tests/dummy/app/controllers/hero/index.js
+++ b/tests/dummy/app/controllers/hero/index.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { opacity } from 'ember-animated/motions/opacity';
+import opacity from 'ember-animated/motions/opacity';
 
 function * transition({ insertedSprites, receivedSprites, removedSprites }) {
   insertedSprites.forEach(sprite => {

--- a/tests/dummy/app/controllers/inline-text.js
+++ b/tests/dummy/app/controllers/inline-text.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import Opacity from 'ember-animated/motions/opacity';
+import { opacity } from 'ember-animated/motions/opacity';
 import { Promise } from 'ember-animated/concurrency-helpers';
 
 export default Controller.extend({
@@ -14,15 +14,15 @@ export default Controller.extend({
 
 function fade(initialRender) {
   if (!initialRender) {
-    return function * () {
+    return function * ({ removedSprites, insertedSprites, keptSprites }) {
       // We yield Promise.all here because we want to wait for this
       // step before starting what comes after.
-      yield Promise.all(this.removedSprites.map(s => {
+      yield Promise.all(removedSprites.map(s => {
         if (s.revealed) {
-          return this.animate(new Opacity(s, {
+          return opacity(s, {
             to: 0,
             duration: this.duration / 2
-          }));
+          });
         }
       }));
 
@@ -30,10 +30,10 @@ function fade(initialRender) {
       // or kept sprites. Note that we get keptSprites if some things
       // were fading out and then we get interrupted and decide to
       // keep them around after all.
-      this.insertedSprites.concat(this.keptSprites).map(s => this.animate(new Opacity(s, {
+      insertedSprites.concat(keptSprites).map(s => opacity(s, {
         to: 1,
         duration: this.duration / 2
-      })));
+      }));
     };
   }
 }

--- a/tests/dummy/app/controllers/inline-text.js
+++ b/tests/dummy/app/controllers/inline-text.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { opacity } from 'ember-animated/motions/opacity';
+import opacity from 'ember-animated/motions/opacity';
 import { Promise } from 'ember-animated/concurrency-helpers';
 
 export default Controller.extend({

--- a/tests/dummy/app/controllers/nested.js
+++ b/tests/dummy/app/controllers/nested.js
@@ -1,6 +1,6 @@
 import { A } from '@ember/array';
 import Controller from '@ember/controller';
-import Move from 'ember-animated/motions/move';
+import { move } from 'ember-animated/motions/move';
 
 export default Controller.extend({
   rules,
@@ -46,32 +46,30 @@ export default Controller.extend({
 
 let counter = 0;
 
-function * first() {
-  this.insertedSprites.forEach(sprite => {
+function * first({ insertedSprites, keptSprites }) {
+  insertedSprites.forEach(sprite => {
     sprite.reveal();
   });
 
-  this.keptSprites.forEach(sprite => {
-    this.animate(new Move(sprite));
-  });
+  keptSprites.forEach(move);
 }
 
-function * subsequent() {
-  this.insertedSprites.forEach(sprite => {
+function * subsequent({ insertedSprites, keptSprites, removedSprites }) {
+  insertedSprites.forEach(sprite => {
     sprite.startAtPixel({ x: window.outerWidth });
-    this.animate(new Move(sprite));
+    move(sprite);
   });
 
-  this.keptSprites.forEach(sprite => {
-    this.animate(new Move(sprite));
+  keptSprites.forEach(sprite => {
+    move(sprite);
   });
 
-  this.removedSprites.forEach(sprite => {
+  removedSprites.forEach(sprite => {
     // the 0.8 here is purely so I can easily see that the elements
     // are being properly removed immediately after they get far
     // enough
     sprite.endAtPixel({ x: window.outerWidth * 0.8 });
-    this.animate(new Move(sprite));
+    move(sprite);
   });
 
 }

--- a/tests/dummy/app/controllers/nested.js
+++ b/tests/dummy/app/controllers/nested.js
@@ -1,6 +1,6 @@
 import { A } from '@ember/array';
 import Controller from '@ember/controller';
-import { move } from 'ember-animated/motions/move';
+import move from 'ember-animated/motions/move';
 
 export default Controller.extend({
   rules,

--- a/tests/dummy/app/controllers/orphan.js
+++ b/tests/dummy/app/controllers/orphan.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
-import Opacity from 'ember-animated/motions/opacity';
-import Move from 'ember-animated/motions/move';
+import { opacity } from 'ember-animated/motions/opacity';
+import { move } from 'ember-animated/motions/move';
 
 export default Controller.extend({
   showDetail: true,
@@ -13,21 +13,21 @@ export default Controller.extend({
   }
 });
 
-function * fade() {
-  this.insertedSprites.forEach(s => this.animate(new Opacity(s, { from: 0 })));
-  this.receivedSprites.forEach(s => this.animate(new Opacity(s)));
-  this.removedSprites.forEach(s => this.animate(new Opacity(s, { to: 0 })));
+function * fade({ insertedSprites, receivedSprites, removedSprites }) {
+  insertedSprites.forEach(s => opacity(s, { from: 0 }));
+  receivedSprites.forEach(s => opacity(s));
+  removedSprites.forEach(s => opacity(s, { to: 0 }));
 }
 
 
-function * fromSide() {
-  this.insertedSprites.forEach(s => {
+function * fromSide({ insertedSprites, receivedSprites, removedSprites }) {
+  insertedSprites.forEach(s => {
     s.startAtPixel({ x: window.outerWidth * 0.8 });
-    this.animate(new Move(s));
+    move(s);
   });
-  this.receivedSprites.forEach(s => this.animate(new Move(s)));
-  this.removedSprites.forEach(s => {
+  receivedSprites.forEach(move);
+  removedSprites.forEach(s => {
     s.endAtPixel({ x: window.outerWidth * 0.8 });
-    this.animate(new Move(s));
+    move(s);
   });
 }

--- a/tests/dummy/app/controllers/orphan.js
+++ b/tests/dummy/app/controllers/orphan.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
-import { opacity } from 'ember-animated/motions/opacity';
-import { move } from 'ember-animated/motions/move';
+import opacity from 'ember-animated/motions/opacity';
+import move from 'ember-animated/motions/move';
 
 export default Controller.extend({
   showDetail: true,

--- a/tests/integration/components/animated-each-test.js
+++ b/tests/integration/components/animated-each-test.js
@@ -47,8 +47,8 @@ module('Integration | Component | animated each', function(hooks) {
   test('it can transition at first render', async function(assert) {
     let transitionCounter = 0;
     this.set('items', ['a', 'b', 'c']);
-    this.set('transition', function * () {
-      assert.equal(this.insertedSprites.length, 3);
+    this.set('transition', function * ({ insertedSprites }) {
+      assert.equal(insertedSprites.length, 3);
       transitionCounter++;
     });
     await render(hbs`
@@ -66,11 +66,11 @@ module('Integration | Component | animated each', function(hooks) {
   test('it updates when list is replaced', async function(assert) {
     let transitionCounter = 0;
     this.set('items', ['a', 'b', 'c']);
-    this.set('transition', function * () {
+    this.set('transition', function * ({ insertedSprites, removedSprites, keptSprites }) {
       if (++transitionCounter === 2) {
-        assert.equal(this.keptSprites.length, 2, 'kept sprites');
-        assert.equal(this.insertedSprites.length, 1, 'inserted sprites');
-        assert.equal(this.removedSprites.length, 1, 'removed sprites');
+        assert.equal(keptSprites.length, 2, 'kept sprites');
+        assert.equal(insertedSprites.length, 1, 'inserted sprites');
+        assert.equal(removedSprites.length, 1, 'removed sprites');
       }
     });
     await render(hbs`
@@ -92,11 +92,11 @@ module('Integration | Component | animated each', function(hooks) {
   test('it updates when list is mutated', async function(assert) {
     let transitionCounter = 0;
     this.set('items', A(['a', 'b', 'c']));
-    this.set('transition', function * () {
+    this.set('transition', function * ({ insertedSprites, removedSprites, keptSprites }) {
       if (++transitionCounter === 2) {
-        assert.equal(this.keptSprites.length, 2, 'kept sprites');
-        assert.equal(this.insertedSprites.length, 1, 'inserted sprites');
-        assert.equal(this.removedSprites.length, 1, 'removed sprites');
+        assert.equal(keptSprites.length, 2, 'kept sprites');
+        assert.equal(insertedSprites.length, 1, 'inserted sprites');
+        assert.equal(removedSprites.length, 1, 'removed sprites');
       }
     });
     await render(hbs`
@@ -116,11 +116,11 @@ module('Integration | Component | animated each', function(hooks) {
     assert.expect(5);
     let transitionCounter = 0;
     this.set('items', A([{ id: 'a'}, {id: 'b'}, {id: 'c'}]));
-    this.set('transition', function * () {
+    this.set('transition', function * ({ insertedSprites, removedSprites, keptSprites }) {
       if (++transitionCounter === 2) {
-        assert.equal(this.keptSprites.length, 2, 'kept sprites');
-        assert.equal(this.insertedSprites.length, 1, 'inserted sprites');
-        assert.equal(this.removedSprites.length, 1, 'removed sprites');
+        assert.equal(keptSprites.length, 2, 'kept sprites');
+        assert.equal(insertedSprites.length, 1, 'inserted sprites');
+        assert.equal(removedSprites.length, 1, 'removed sprites');
       }
     });
     await render(hbs`
@@ -140,11 +140,11 @@ module('Integration | Component | animated each', function(hooks) {
     assert.expect(5);
     let transitionCounter = 0;
     this.set('items', A([{ id: 'a', x: 1, y: 2}, {id: 'b'}, {id: 'c'}]));
-    this.set('transition', function * () {
+    this.set('transition', function * ({ insertedSprites, removedSprites, keptSprites }) {
       if (++transitionCounter === 2) {
-        assert.equal(this.keptSprites.length, 3, 'kept sprites');
-        assert.equal(this.insertedSprites.length, 0, 'inserted sprites');
-        assert.equal(this.removedSprites.length, 0, 'removed sprites');
+        assert.equal(keptSprites.length, 3, 'kept sprites');
+        assert.equal(insertedSprites.length, 0, 'inserted sprites');
+        assert.equal(removedSprites.length, 0, 'removed sprites');
       }
     });
     await render(hbs`
@@ -169,8 +169,8 @@ module('Integration | Component | animated each', function(hooks) {
     this.set('leftItems', A([{ id: 'a'}, {id: 'b'}, {id: 'c'}]));
     this.set('rightItems', A([]));
 
-    this.set('leftTransition', function * () {
-      assert.equal(this.insertedSprites.length, 3, "first transition");
+    this.set('leftTransition', function * ({ insertedSprites }) {
+      assert.equal(insertedSprites.length, 3, "first transition");
     });
 
     this.set('rightTransition', function * () {
@@ -188,20 +188,20 @@ module('Integration | Component | animated each', function(hooks) {
 
     await animationsSettled();
 
-    this.set('leftTransition', function * () {
-      assert.equal(this.keptSprites.length, 2, "left kept");
-      assert.equal(this.removedSprites.length, 0, "left removed");
-      assert.equal(this.sentSprites.length, 1, "left sent");
-      assert.equal(this.receivedSprites.length, 0, "left received");
-      assert.equal(this.insertedSprites.length, 0, "left inserted");
+    this.set('leftTransition', function * ({ receivedSprites, insertedSprites, removedSprites, keptSprites, sentSprites }) {
+      assert.equal(keptSprites.length, 2, "left kept");
+      assert.equal(removedSprites.length, 0, "left removed");
+      assert.equal(sentSprites.length, 1, "left sent");
+      assert.equal(receivedSprites.length, 0, "left received");
+      assert.equal(insertedSprites.length, 0, "left inserted");
     });
 
-    this.set('rightTransition', function * () {
-      assert.equal(this.keptSprites.length, 0, "right kept");
-      assert.equal(this.removedSprites.length, 0, "right removed");
-      assert.equal(this.sentSprites.length, 0, "right sent");
-      assert.equal(this.receivedSprites.length, 1, "right received");
-      assert.equal(this.insertedSprites.length, 0, "right inserted");
+    this.set('rightTransition', function * ({ receivedSprites, insertedSprites, removedSprites, keptSprites, sentSprites }) {
+      assert.equal(keptSprites.length, 0, "right kept");
+      assert.equal(removedSprites.length, 0, "right removed");
+      assert.equal(sentSprites.length, 0, "right sent");
+      assert.equal(receivedSprites.length, 1, "right received");
+      assert.equal(insertedSprites.length, 0, "right inserted");
 
     });
 
@@ -216,8 +216,8 @@ module('Integration | Component | animated each', function(hooks) {
     this.set('leftItems', A([{ id: 'a'}, {id: 'b'}, {id: 'c'}]));
     this.set('rightItems', A([{id: 'b'}, ]));
 
-    this.set('leftTransition', function * () {
-      assert.equal(this.insertedSprites.length, 3, "first transition");
+    this.set('leftTransition', function * ({ insertedSprites }) {
+      assert.equal(insertedSprites.length, 3, "first transition");
     });
 
     this.set('rightTransition', function * () {
@@ -245,8 +245,8 @@ module('Integration | Component | animated each', function(hooks) {
       throw new Error("unexpected left transition");
     });
 
-    this.set('rightTransition', function * () {
-      assert.equal(this.receivedSprites.length, 1, "right found match");
+    this.set('rightTransition', function * ({ receivedSprites }) {
+      assert.equal(receivedSprites.length, 1, "right found match");
     });
 
     this.set('leftAlive', false);
@@ -280,19 +280,19 @@ module('Integration | Component | animated each', function(hooks) {
 
     await animationsSettled();
 
-    this.set('outerTransition', function * () {
-      assert.deepEqual(this.keptSprites.map(s => s.owner.id), ['a', 'c'], 'kept sprites');
-      assert.deepEqual(this.insertedSprites.map(s => s.owner.id), [], 'inserted sprites');
-      assert.deepEqual(this.removedSprites.map(s => s.owner.id), ['b'], 'removed sprites');
+    this.set('outerTransition', function * ({ insertedSprites, removedSprites, keptSprites }) {
+      assert.deepEqual(keptSprites.map(s => s.owner.id), ['a', 'c'], 'kept sprites');
+      assert.deepEqual(insertedSprites.map(s => s.owner.id), [], 'inserted sprites');
+      assert.deepEqual(removedSprites.map(s => s.owner.id), ['b'], 'removed sprites');
     });
 
     let innerCounter = 0;
 
-    this.set('innerTransition', function * () {
+    this.set('innerTransition', function * ({ insertedSprites, removedSprites, keptSprites }) {
       innerCounter++;
-      assert.deepEqual(this.keptSprites.map(s => s.owner.id), [], 'kept sprites');
-      assert.deepEqual(this.insertedSprites.map(s => s.owner.id), [], 'inserted sprites');
-      assert.deepEqual(this.removedSprites.map(s => s.owner.id), ['comment-b'], 'removed sprites');
+      assert.deepEqual(keptSprites.map(s => s.owner.id), [], 'kept sprites');
+      assert.deepEqual(insertedSprites.map(s => s.owner.id), [], 'inserted sprites');
+      assert.deepEqual(removedSprites.map(s => s.owner.id), ['comment-b'], 'removed sprites');
     });
 
     this.set('items', ['a', 'c'].map(makeItem));
@@ -337,12 +337,12 @@ module('Integration | Component | animated each', function(hooks) {
     let sawOuter, sawInner;
     let outerIsAnimating = new Promise(r => sawOuter = r);
     let innerIsAnimating = new Promise(r => sawInner = r);
-    this.set('outerTransition', function * () {
-      this.removedSprites.forEach(s => this.animate(new TestMotion(s)));
+    this.set('outerTransition', function * ({ removedSprites }) {
+      removedSprites.forEach(s => new TestMotion(s).run());
       sawOuter();
     });
-    this.set('innerTransition', function * () {
-      this.removedSprites.forEach(s => this.animate(new TestMotion(s)));
+    this.set('innerTransition', function * ({ removedSprites }) {
+      removedSprites.forEach(s => new TestMotion(s).run());
       sawInner();
     });
 
@@ -353,18 +353,18 @@ module('Integration | Component | animated each', function(hooks) {
     await outerIsAnimating;
     await innerIsAnimating;
 
-    this.set('outerTransition', function * () {
-      assert.deepEqual(this.keptSprites.map(s => s.owner.id).sort(), ['a', 'b', 'c'], 'kept sprites');
-      assert.deepEqual(this.insertedSprites.map(s => s.owner.id), [], 'inserted sprites');
-      assert.deepEqual(this.removedSprites.map(s => s.owner.id), [], 'removed sprites');
+    this.set('outerTransition', function * ({ insertedSprites, removedSprites, keptSprites }) {
+      assert.deepEqual(keptSprites.map(s => s.owner.id).sort(), ['a', 'b', 'c'], 'kept sprites');
+      assert.deepEqual(insertedSprites.map(s => s.owner.id), [], 'inserted sprites');
+      assert.deepEqual(removedSprites.map(s => s.owner.id), [], 'removed sprites');
     });
 
     let innerCounter = 0;
-    this.set('innerTransition', function * () {
+    this.set('innerTransition', function * ({ receivedSprites, insertedSprites, removedSprites }) {
       innerCounter++;
-      assert.deepEqual(this.receivedSprites.map(s => s.owner.id), ['comment-b'], 'received sprites');
-      assert.deepEqual(this.insertedSprites.map(s => s.owner.id), [], 'inserted sprites');
-      assert.deepEqual(this.removedSprites.map(s => s.owner.id), [], 'removed sprites');
+      assert.deepEqual(receivedSprites.map(s => s.owner.id), ['comment-b'], 'received sprites');
+      assert.deepEqual(insertedSprites.map(s => s.owner.id), [], 'inserted sprites');
+      assert.deepEqual(removedSprites.map(s => s.owner.id), [], 'removed sprites');
     });
 
 

--- a/tests/unit/move-test.js
+++ b/tests/unit/move-test.js
@@ -2,7 +2,7 @@ import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import Sprite from 'ember-animated/sprite';
 import $ from 'jquery';
-import Move from 'ember-animated/motions/move';
+import { Move } from 'ember-animated/motions/move';
 import {
   equalBounds,
   approxEqualPixels,

--- a/tests/unit/opacity-test.js
+++ b/tests/unit/opacity-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import Sprite from 'ember-animated/sprite';
 import $ from 'jquery';
-import Opacity from 'ember-animated/motions/opacity';
+import { Opacity } from 'ember-animated/motions/opacity';
 import { MotionTester, TimeControl } from 'ember-animated/test-support';
 
 let tester, target, time;


### PR DESCRIPTION
- this makes it clearer that normal function composition works and is good
 - less total noise in transitions
 - move some conventional boilerplate (new Motion) into motions themselves, so that callers don't need it
 - drop the need for animate() on transition context by putting run() on Motion
deb904f