### PR TITLE
removes jQuery from the tests & demo app

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -16,7 +16,8 @@ module.exports = function() {
           name: 'ember-lts-2.12',
           npm: {
             devDependencies: {
-              'ember-source': '~2.12.0'
+              'ember-source': '~2.12.0',
+              'ember-native-dom-event-dispatcher': '~0.6.4'
             }
           }
         },
@@ -24,7 +25,8 @@ module.exports = function() {
           name: 'ember-lts-2.16',
           npm: {
             devDependencies: {
-              'ember-source': '~2.16.0'
+              'ember-source': '~2.16.0',
+              'ember-native-dom-event-dispatcher': '~0.6.4'
             }
           }
         },
@@ -32,7 +34,8 @@ module.exports = function() {
           name: 'ember-lts-2.18',
           npm: {
             devDependencies: {
-              'ember-source': '~2.18.0'
+              'ember-source': '~2.18.0',
+              'ember-native-dom-event-dispatcher': '~0.6.4'
             }
           }
         },

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,7 @@ var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
-    vendorFiler: { 'jquery.js': null, 'app-shims.js': null }
+    vendorFiles: { 'jquery.js': null, 'app-shims.js': null }
   });
   return app.toTree();
 };

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "ember-resolver": "^4.0.0",
     "ember-source": "~3.0.0",
     "ember-source-channel-url": "^1.0.1",
+    "ember-truth-helpers": "^2.0.0",
     "ember-try": "^0.2.23",
     "eslint": "~4.15.0",
     "eslint-plugin-ember": "^5.0.0",

--- a/tests/dummy/app/templates/components/bind-example.hbs
+++ b/tests/dummy/app/templates/components/bind-example.hbs
@@ -15,5 +15,5 @@
 
   <button {{action "increment"}}>+</button>
   <button {{action "decrement"}}>-</button>
-  {{input type="checkbox" checked=showBoth}}
+  <input type="checkbox" checked={{showBoth}} onchange={{action (mut showBoth) (not showBoth)}}>
 </div>

--- a/tests/dummy/app/templates/components/swapping-lists-example.hbs
+++ b/tests/dummy/app/templates/components/swapping-lists-example.hbs
@@ -4,8 +4,14 @@
   </div>
   <div>
     <button {{action "swap"}}>Swap</button>
-    <label>{{input type="checkbox" checked=distinguishSides}} Distinguish by color</label>
-    <label class="sending-side">{{input type="checkbox" checked=animateSendingSide}} Animate sending side</label>
+    <label>
+      <input type="checkbox" checked={{distinguishSides}} onchange={{action (mut distinguishSides) (not distinguishSides)}}>
+      Distinguish by color
+    </label>
+    <label class="sending-side">
+      <input type="checkbox" checked={{animateSendingSide}} onchange={{action (mut animateSendingSide) (not animateSendingSide)}}>
+      Animate sending side
+    </label>
   </div>
 
   {{#if leftItems}}

--- a/tests/dummy/app/templates/components/swapping-lists-example.hbs
+++ b/tests/dummy/app/templates/components/swapping-lists-example.hbs
@@ -4,14 +4,8 @@
   </div>
   <div>
     <button {{action "swap"}}>Swap</button>
-    <label>
-      <input type="checkbox" checked={{distinguishSides}} onchange={{action (mut distinguishSides) (not distinguishSides)}}>
-      Distinguish by color
-    </label>
-    <label class="sending-side">
-      <input type="checkbox" checked={{animateSendingSide}} onchange={{action (mut animateSendingSide) (not animateSendingSide)}}>
-      Animate sending side
-    </label>
+    <label><input type="checkbox" checked={{distinguishSides}} onchange={{action (mut distinguishSides) (not distinguishSides)}}>Distinguish by color</label>
+    <label class="sending-side"><input type="checkbox" checked={{animateSendingSide}} onchange={{action (mut animateSendingSide) (not animateSendingSide)}}> Animate sending side</label>
   </div>
 
   {{#if leftItems}}

--- a/tests/dummy/app/templates/components/two-lists-example.hbs
+++ b/tests/dummy/app/templates/components/two-lists-example.hbs
@@ -1,6 +1,6 @@
 <div class="scenario-two-lists">
   <div class="controls">
-    <label>Bounce back {{input type="checkbox" checked=bounceBack}}</label>
+    <label>Bounce back <input type="checkbox" checked={{bounceBack}} onchange={{action (mut bounceBack) (not bounceBack)}}></label>
   </div>
 
   {{#animated-container}}

--- a/tests/dummy/app/templates/demos/here-there.hbs
+++ b/tests/dummy/app/templates/demos/here-there.hbs
@@ -2,10 +2,7 @@
 
   <button {{action "toggle"}}>Toggle</button>
 
-  <label>
-    <input type="checkbox" checked={{groupTogether}} onchange={{action (mut groupTogether) (not groupTogether)}}>
-    Grouped
-  </label>
+  <label><input type="checkbox" checked={{groupTogether}} onchange={{action (mut groupTogether) (not groupTogether)}}> Grouped</label>
 
   <div>
     <div class="left">

--- a/tests/dummy/app/templates/demos/here-there.hbs
+++ b/tests/dummy/app/templates/demos/here-there.hbs
@@ -2,7 +2,10 @@
 
   <button {{action "toggle"}}>Toggle</button>
 
-  <label>{{input type="checkbox" checked=groupTogether}} Grouped</label>
+  <label>
+    <input type="checkbox" checked={{groupTogether}} onchange={{action (mut groupTogether) (not groupTogether)}}>
+    Grouped
+  </label>
 
   <div>
     <div class="left">


### PR DESCRIPTION
Thanks mostly to @cibernox's hard work we have nearly everything working without jQuery.

The final issue is that there are some acceptance tests that use checkbox, and apparently Ember's own checkbox component depends on jQuery until [very recently](https://github.com/emberjs/ember.js/commit/a233625150b484ae473e0c590f6e3efade1f4658).