### PR TITLE
Remove jQuery, app-shims and use native checkboxes

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,7 @@ var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
-    vendorFiler: { 'jquery.js': null, 'app-shims.js': null }
+    vendorFiles: { 'jquery.js': null, 'app-shims.js': null }
   });
   return app.toTree();
 };

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "ember-resolver": "^4.0.0",
     "ember-source": "~3.0.0",
     "ember-source-channel-url": "^1.0.1",
+    "ember-truth-helpers": "^2.0.0",
     "ember-try": "^0.2.23",
     "eslint": "~4.15.0",
     "eslint-plugin-ember": "^5.0.0",

--- a/tests/dummy/app/templates/components/bind-example.hbs
+++ b/tests/dummy/app/templates/components/bind-example.hbs
@@ -15,5 +15,5 @@
 
   <button {{action "increment"}}>+</button>
   <button {{action "decrement"}}>-</button>
-  {{input type="checkbox" checked=showBoth}}
+  <input type="checkbox" checked={{showBoth}} onchange={{action (mut showBoth) (not showBoth)}}>
 </div>

--- a/tests/dummy/app/templates/components/swapping-lists-example.hbs
+++ b/tests/dummy/app/templates/components/swapping-lists-example.hbs
@@ -4,8 +4,8 @@
   </div>
   <div>
     <button {{action "swap"}}>Swap</button>
-    <label>{{input type="checkbox" checked=distinguishSides}} Distinguish by color</label>
-    <label class="sending-side">{{input type="checkbox" checked=animateSendingSide}} Animate sending side</label>
+    <label><input type="checkbox" checked={{distinguishSides}} onchange={{action (mut distinguishSides) (not distinguishSides)}}>Distinguish by color</label>
+    <label class="sending-side"><input type="checkbox" checked={{animateSendingSide}} onchange={{action (mut animateSendingSide) (not animateSendingSide)}}> Animate sending side</label>
   </div>
 
   {{#if leftItems}}

--- a/tests/dummy/app/templates/components/two-lists-example.hbs
+++ b/tests/dummy/app/templates/components/two-lists-example.hbs
@@ -1,6 +1,6 @@
 <div class="scenario-two-lists">
   <div class="controls">
-    <label>Bounce back {{input type="checkbox" checked=bounceBack}}</label>
+    <label>Bounce back <input type="checkbox" checked={{bounceBack}} onchange={{action (mut bounceBack) (not bounceBack)}}></label>
   </div>
 
   {{#animated-container}}

--- a/tests/dummy/app/templates/demos/here-there.hbs
+++ b/tests/dummy/app/templates/demos/here-there.hbs
@@ -2,7 +2,7 @@
 
   <button {{action "toggle"}}>Toggle</button>
 
-  <label>{{input type="checkbox" checked=groupTogether}} Grouped</label>
+  <label><input type="checkbox" checked={{groupTogether}} onchange={{action (mut groupTogether) (not groupTogether)}}> Grouped</label>
 
   <div>
     <div class="left">


### PR DESCRIPTION
@ef4 The simplest solution was to use "native" checboxes. They are slightly more verbose, but also more performant and they don't need jquery.