### PR TITLE
Multiple beacons

### DIFF
--- a/addon/-private/transition-context.js
+++ b/addon/-private/transition-context.js
@@ -1,7 +1,7 @@
 import { childrenSettled } from './scheduler';
 
 export default class TransitionContext {
-  constructor(duration, insertedSprites, keptSprites, removedSprites, sentSprites, receivedSprites) {
+  constructor(duration, insertedSprites, keptSprites, removedSprites, sentSprites, receivedSprites, beacons) {
     this._duration = duration;
     this._insertedSprites = insertedSprites;
     this._keptSprites = keptSprites;
@@ -9,6 +9,7 @@ export default class TransitionContext {
     this._sentSprites = sentSprites;
     this._receivedSprites = receivedSprites;
     this._prepared = new Set();
+    this._beacons = beacons;
   }
 
   // the following things are all accessors in order to make them
@@ -32,6 +33,10 @@ export default class TransitionContext {
   }
   get receivedSprites() {
     return this._prepareSprites(this._receivedSprites);
+  }
+
+  get beacons() {
+    return this._beacons;
   }
 
   _prepareSprites(sprites) {

--- a/addon/components/animated-beacon.js
+++ b/addon/components/animated-beacon.js
@@ -11,11 +11,11 @@ import Sprite from '../-private/sprite';
   can serve as a source or destination for other animator components. 
   See [Animating Between Components](../../between).  
   ```hbs
-    {{#animated-beacon group="one"}}
+    {{#animated-beacon name="one"}}
       <button {{action "launch"}}>Launch</button>
     {{/animated-beacon}}
 
-    {{#animated-if showThing group="one" use=transition duration=500}}
+    {{#animated-if showThing use=transition duration=500}}
       <div class="message" {{action "dismiss"}}>
         Hello
       </div>

--- a/addon/components/animated-beacon.js
+++ b/addon/components/animated-beacon.js
@@ -30,10 +30,20 @@ import Sprite from '../-private/sprite';
   export default Component.extend({
     showThing: false,
 
-    transition: function * ({ receivedSprites, sentSprites }) {
-      receivedSprites.forEach(parallel(scale, move));
-      sentSprites.forEach(parallel(scale, move));
-    },
+    transition: function * (context) {
+      let { insertedSprites, removedSprites, keptSprites, beacons } = context;
+      insertedSprites.forEach(sprite => {
+        sprite.startAtSprite(beacons.one);
+        parallel(move(sprite, scale(sprite)));
+    });
+
+    keptSprites.forEach(move);
+      
+    removedSprites.forEach(sprite => {
+      sprite.endAtSprite(beacons.one);
+      parallel(move(sprite, scale(sprite)));
+    });
+  },
 
     actions: {
       launch() {

--- a/addon/components/animated-beacon.js
+++ b/addon/components/animated-beacon.js
@@ -6,8 +6,6 @@ import { afterRender, microwait } from '..';
 import { componentNodes } from '../-private/ember-internals';
 import Sprite from '../-private/sprite';
 
-export const WILDCARD = {};
-
 /**
   A component that marks a region of the page that 
   can serve as a source or destination for other animator components. 
@@ -93,10 +91,8 @@ export default Component.extend({
     if (!element) {
       return;
     }
-    let group = this.get('group') || '__default__';
     let offsetParent = Sprite.offsetParentStartingAt(element);
     let sprite = Sprite.positionedStartingAt(element, offsetParent);
-    sprite.owner = { group, id: WILDCARD };
 
     yield afterRender();
     yield microwait();

--- a/addon/components/animated-each.js
+++ b/addon/components/animated-each.js
@@ -490,7 +490,7 @@ export default Component.extend({
     // some of our sprites may match up with sprites that are entering
     // or leaving other simulatneous animators. So we hit another
     // coordination point via the motionService
-    let { farMatches, matchingAnimatorsFinished } = yield this.get('motionService.farMatch').perform(
+    let { farMatches, matchingAnimatorsFinished, beacons } = yield this.get('motionService.farMatch').perform(
       current(),
       insertedSprites,
       keptSprites,
@@ -576,7 +576,9 @@ export default Component.extend({
       unmatchedKeptSprites,                          // user-visible keptSprites
       unmatchedRemovedSprites,                       // user-visible removedSprites
       sentSprites,                                   // user-visible sentSprites
-      receivedSprites.concat(matchedKeptSprites)     // user-visible receivedSprites
+      receivedSprites.concat(matchedKeptSprites),    // user-visible receivedSprites
+      beacons
+
     );
     let cycle = this._cycleCounter++;
     context.onMotionStart = sprite => this._motionStarted(sprite, cycle);

--- a/addon/services/motion.js
+++ b/addon/services/motion.js
@@ -8,7 +8,7 @@ import {
   afterRender,
   allSettled
 } from '..';
-import { WILDCARD } from '../components/animated-beacon';
+
 
 const MotionService = Service.extend({
   init() {
@@ -275,12 +275,7 @@ function performMatches(sink, source) {
   sink.inserted.concat(sink.kept).forEach(sprite => {
     let match = source.removed.find(
       mySprite =>
-        sprite.owner.group == mySprite.owner.group && (
-          sprite.owner.id === WILDCARD ||
-            mySprite.owner.id === WILDCARD ||
-            sprite.owner.id === mySprite.owner.id
-        )
-    );
+        sprite.owner.group == mySprite.owner.group && sprite.owner.id === mySprite.owner.id);
     if (match) {
       sink.matches.set(sprite, match);
       sink.otherTasks.set(source.runAnimationTask, true);

--- a/addon/services/motion.js
+++ b/addon/services/motion.js
@@ -20,6 +20,7 @@ const MotionService = Service.extend({
     this._animationObservers = [];
     this._descendantObservers = [];
     this._ancestorObservers = new WeakMap();
+    this._beacons = null;
   },
 
   // === Notification System ===
@@ -162,6 +163,22 @@ const MotionService = Service.extend({
     }
   },
 
+  addBeacon: task(function * (name, beacon) {
+    if(!this._beacons) {
+      this._beacons = {};
+    }
+    if(this._beacons[name]){
+      throw new Error("There is more than one beacon named", name);
+    }
+
+    this._beacons[name] = beacon;
+    // allows other farMatches to start
+    yield microwait();
+    // allows other farMatches to finish
+    yield microwait();
+    this._beacons = null;
+  }),
+
   farMatch: task(function * (runAnimationTask, inserted, kept, removed, longWait=false) {
     let matches = new Map();
     let mine = { inserted, kept, removed, matches, runAnimationTask, otherTasks: new Map() };
@@ -186,7 +203,8 @@ const MotionService = Service.extend({
     this._rendezvous.splice(this._rendezvous.indexOf(mine), 1);
     return {
       farMatches: matches,
-      matchingAnimatorsFinished: allSettled([...mine.otherTasks.keys()])
+      matchingAnimatorsFinished: allSettled([...mine.otherTasks.keys()]),
+      beacons: this._beacons
     };
   }),
 

--- a/tests/dummy/app/components/beacon-demo.js
+++ b/tests/dummy/app/components/beacon-demo.js
@@ -8,9 +8,19 @@ import { parallel } from 'ember-animated';
 export default Component.extend({
   showThing: false,
 
-  transition: function * ({ receivedSprites, sentSprites }) {
-    receivedSprites.forEach(parallel(scale, move));
-    sentSprites.forEach(parallel(scale, move));
+  transition: function * (context) {
+    let { insertedSprites, removedSprites, keptSprites, beacons } = context;
+    insertedSprites.forEach(sprite => {
+      sprite.startAtSprite(beacons.one);
+      parallel(move(sprite, scale(sprite)));
+    });
+
+    keptSprites.forEach(move);
+      
+    removedSprites.forEach(sprite => {
+      sprite.endAtSprite(beacons.one);
+      parallel(move(sprite, scale(sprite)));
+    });
   },
 
   actions: {

--- a/tests/dummy/app/controllers/demos/beacon.js
+++ b/tests/dummy/app/controllers/demos/beacon.js
@@ -7,10 +7,22 @@ import { parallel } from 'ember-animated';
 export default Controller.extend({
   showingModal: false,
 
-  transition: function * ({ receivedSprites, sentSprites }) {
-    receivedSprites.forEach(parallel(scale, move));
-    sentSprites.forEach(parallel(scale, move, opacity));
+
+  transition: function * (context) {
+    let { insertedSprites, removedSprites, keptSprites, beacons } = context;
+    insertedSprites.forEach(sprite => {
+      sprite.startAtSprite(beacons.beacontest);
+      parallel(move(sprite, scale(sprite)));
+    });
+
+    keptSprites.forEach(move);
+      
+    removedSprites.forEach(sprite => {
+      sprite.endAtSprite(beacons.beacontest);
+      parallel(move(sprite, scale(sprite), opacity));
+    });
   },
+
 
   actions: {
     launch() {

--- a/tests/dummy/app/templates/components/beacon-demo.hbs
+++ b/tests/dummy/app/templates/components/beacon-demo.hbs
@@ -1,8 +1,8 @@
-{{#animated-beacon group="one"}}
+{{#animated-beacon name="one"}}
   <button {{action "launch"}}>Launch</button>
 {{/animated-beacon}}
 
-{{#animated-if showThing group="one" use=transition duration=500}}
+{{#animated-if showThing use=transition duration=500}}
   <div class="message" {{action "dismiss"}}>
     Hello
   </div>

--- a/tests/dummy/app/templates/demos/beacon.hbs
+++ b/tests/dummy/app/templates/demos/beacon.hbs
@@ -1,11 +1,11 @@
 <div class="scenario-beacon">
-  {{#animated-beacon group="beacon-test"}}
+  {{#animated-beacon name="beacontest"}}
     <button {{action "launch"}}>Launch</button>
   {{/animated-beacon}}
 </div>
 
 
-{{#animated-if showingModal group="beacon-test" use=transition duration=500}}
+{{#animated-if showingModal use=transition duration=500}}
   <div class="scenario-beacon-modal" {{action "dismiss"}}>
       Hi
   </div>

--- a/tests/integration/components/animated-beacon-test.js
+++ b/tests/integration/components/animated-beacon-test.js
@@ -7,35 +7,14 @@ import { animationsSettled, bounds } from 'ember-animated/test-support';
 module('Integration | Component | animated-beacon', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it can match using specific group', async function(assert) {
+  test('beacons are available in transitions', async function(assert) {
     assert.expect(1);
-    this.set('transition', function * ({ receivedSprites }) {
-      assert.equal(receivedSprites.length, 1, 'expected one received sprite');
+    this.set('transition', function * ({ beacons }) {
+      assert.ok(beacons.thegroup, 'expected one beacon');
     });
 
     await render(hbs`
-{{#animated-beacon group="the-group"}}
-  <div class="alpha"></div>
-{{/animated-beacon}}
-
-{{#animated-value showIt use=transition group="the-group"}}
-  <div class="beta"></div>
-{{/animated-value}}
-`);
-
-    this.set('showIt', true);
-    await settled();
-    await animationsSettled();
-  });
-
-  test('it can match using default group', async function(assert) {
-    assert.expect(1);
-    this.set('transition', function * ({ receivedSprites }) {
-      assert.equal(receivedSprites.length, 1, 'expected one received sprite');
-    });
-
-    await render(hbs`
-{{#animated-beacon}}
+{{#animated-beacon name="thegroup"}}
   <div class="alpha"></div>
 {{/animated-beacon}}
 
@@ -47,7 +26,6 @@ module('Integration | Component | animated-beacon', function(hooks) {
     this.set('showIt', true);
     await settled();
     await animationsSettled();
-
   });
 
   test('it picks up correct bounds', async function(assert) {
@@ -55,8 +33,10 @@ module('Integration | Component | animated-beacon', function(hooks) {
 
     let alpha;
 
-    this.set('transition', function * ({ receivedSprites }) {
-      let value = bounds(receivedSprites[0].element);
+    this.set('transition', function * ({ insertedSprites, beacons }) {
+      let sprite = insertedSprites[0];
+      sprite.startAtSprite(beacons.thegroup);
+      let value = bounds(sprite.element);
       let expected = bounds(alpha);
 
       // we should be positioned over the beacon
@@ -67,8 +47,8 @@ module('Integration | Component | animated-beacon', function(hooks) {
       // dimensions (the sprite's element physically does not -- it's
       // up to a motion like scale to decide to do that when it's
       // wanted)
-      assert.equal(receivedSprites[0].initialBounds.width, expected.width, 'width');
-      assert.equal(receivedSprites[0].initialBounds.height, expected.height, 'height');
+      assert.equal(beacons.thegroup.initialBounds.width, expected.width, 'width');
+      assert.equal(beacons.thegroup.initialBounds.height, expected.height, 'height');
     });
 
     await render(hbs`
@@ -80,11 +60,11 @@ module('Integration | Component | animated-beacon', function(hooks) {
   }
 </style>
 
-{{#animated-beacon group="the-group"}}
+{{#animated-beacon name="thegroup"}}
   <div class="alpha"></div>
 {{/animated-beacon}}
 
-{{#animated-value showIt use=transition group="the-group"}}
+{{#animated-value showIt use=transition}}
   <div class="beta"></div>
 {{/animated-value}}
 `);


### PR DESCRIPTION
This allows multiple beacons to animate simultaneously. Each beacon has a distinct `name` identifier. Beacons match using `name` which replaced `group`. Beacons are passed into the transition context and treated as sprites that you can animate to and from. 