### PR TITLE
tweaking orphan behaviors

### DIFF
--- a/addon/-private/sprite.js
+++ b/addon/-private/sprite.js
@@ -23,7 +23,9 @@ export const COPIED_CSS_PROPERTIES = [
   'color',
   'background-color',
   'letter-spacing',
+  'line-height',
   'text-align',
+  'text-transform',
 ];
 
 const numericCSSProps = {

--- a/addon/components/animated-orphans.js
+++ b/addon/components/animated-orphans.js
@@ -296,11 +296,18 @@ export default Component.extend({
       // initialComputedStyles that were snapshotted before it was moved. See
       // COPIED_CSS_PROPERTIES to see exactly which property we copy (we don't
       // do all of them, that sounds expensive).
-      sprite.applyStyles(sprite.initialComputedStyle);
+      //
+      // Also, unfortunately getComputedStyles has legacy behavior for
+      // line-height that gives us the "used value" not the "computed value".
+      // The used value doesn't inherit correctly, so we can't set it here, so
+      // we're pulling that one out.
+      let s = Object.assign({}, sprite.initialComputedStyle);
+      delete s['line-height'];
+      sprite.applyStyles(s);
 
+      this.element.appendChild(sprite.element);
       sprite.lock();
       sprite.reveal();
-      this.element.appendChild(sprite.element);
       activeSprites.push(sprite);
       this._elementToChild.set(sprite.element, sprite.owner);
     }


### PR DESCRIPTION
 - copy a few more useful CSS properties 
 - but don't apply line-height to orphan sprites because ugh, legacy getComputedStyles behavior
 - also, appendChild before sprite.lock because trying to lock a sprite that isn't in DOM can explode (when it's an SVG element)