### PR TITLE
Changes default duration from 2000 to 500

### DIFF
--- a/addon/components/animated-each.js
+++ b/addon/components/animated-each.js
@@ -154,7 +154,7 @@ export default Component.extend({
   durationWithDefault: computed('duration', function() {
     let d = this.get('duration');
     if (d == null) {
-      return 2000;
+      return 500;
     } else {
       return d;
     }

--- a/tests/acceptance/container-demo-test.js
+++ b/tests/acceptance/container-demo-test.js
@@ -25,10 +25,10 @@ module('Acceptance | container demo', function(hooks) {
 
     time.pause();
     await click(this.element.querySelector('button'));
-    await time.advance(500);
+    await time.advance(125);
 
     let onePosition = bounds(this.element.querySelector('.message')).left;
-    await time.advance(500);
+    await time.advance(125);
     let twoPosition = bounds(this.element.querySelector('.message')).left;
     assert.ok(twoPosition < onePosition, `expected element .two to be animating in, ${twoPosition } > ${onePosition}`);
   });

--- a/tests/acceptance/if-demo-test.js
+++ b/tests/acceptance/if-demo-test.js
@@ -24,10 +24,10 @@ module('Acceptance | if demo', function(hooks) {
 
     time.pause();
     await click(this.element.querySelector('button'));
-    await time.advance(500);
+    await time.advance(125);
 
     let onePosition = bounds(this.element.querySelector('.message')).left;
-    await time.advance(500);
+    await time.advance(125);
     let twoPosition = bounds(this.element.querySelector('.message')).left;
     assert.ok(twoPosition < onePosition, `expected element .two to be animating in, ${twoPosition } > ${onePosition}`);
   });


### PR DESCRIPTION
BREAKING CHANGE

500 is on the high end for certain interactions but pretty good for animations that move farther across the screen.

I eventually want to add a guide pointing to some research/best practices around keeping durations for web interactions in the 200ms - 500ms range.