### PR TITLE
Update TaskProperty to support Ember 3.10 decorators

### DIFF
--- a/addon/-private/ember-scheduler.js
+++ b/addon/-private/ember-scheduler.js
@@ -59,7 +59,7 @@ if (gte('3.10.0')) {
         super.setup(...arguments);
       }
     }
-  }
+  };
 
 }
 objectAssign(TaskProperty.prototype, {

--- a/addon/-private/ember-scheduler.js
+++ b/addon/-private/ember-scheduler.js
@@ -1,8 +1,10 @@
 import { Promise as EmberPromise } from 'rsvp';
 import { join, scheduleOnce } from '@ember/runloop';
 import { addObserver } from '@ember/object/observers';
-import { set } from '@ember/object';
+import { computed, set } from '@ember/object';
 import ComputedProperty from '@ember/object/computed';
+import { gte } from 'ember-compatibility-helpers';
+import { assign as objectAssign }  from '@ember/polyfills';
 import {
   spawn,
   current,
@@ -13,42 +15,73 @@ import Ember from 'ember';
 import { microwait } from '..';
 import { DEBUG } from '@glimmer/env';
 
-export function task(...args) {
-  return new TaskProperty(...args);
+export function task(taskFn) {
+  let tp = _computed(function(propertyName) {
+    const task = new Task(this, taskFn, tp, propertyName);
+
+    task._bufferPolicy = null;
+    task._observes = null;
+    return task;
+  });
+
+  Object.setPrototypeOf(tp, TaskProperty.prototype);
+  return tp;
+}
+
+function _computed(fn) {
+  if (gte('3.10.0')) {
+    let cp = function(proto, key) {
+      if (cp.setup !== undefined) {
+        cp.setup(proto, key);
+      }
+
+      return computed(fn)(...arguments);
+    };
+
+    Ember._setComputedDecorator(cp);
+
+    return cp;
+  } else {
+    return computed(fn);
+  }
 }
 
 let handlerCounter = 0;
 
-class TaskProperty extends ComputedProperty {
+export let TaskProperty;
 
-  constructor(taskFn) {
-    let tp;
-    super(function (name) {
-      return new Task(this, taskFn, tp, name);
-    });
-    tp = this;
-    this._bufferPolicy = null;
-    this._observes = null;
+if (gte('3.10.0')) {
+  TaskProperty = class {};
+} else {
+  TaskProperty = class extends ComputedProperty {
+    callSuperSetup() {
+      if (super.setup) {
+        super.setup(...arguments);
+      }
+    }
   }
+
+}
+objectAssign(TaskProperty.prototype, {
 
   restartable() {
     this._bufferPolicy = cancelAllButLast;
     return this;
-  }
+  },
 
   drop() {
     this._bufferPolicy = drop;
     return this;
-  }
+  },
 
   observes(...deps) {
     this._observes = deps;
     return this;
-  }
+  },
 
   setup(proto, taskName) {
-    if (super.setup) {
-      super.setup(...arguments);
+    if (this.callSuperSetup) {
+      this.callSuperSetup(...arguments);
     }
 
     if (this._observes) {
@@ -64,7 +97,7 @@ class TaskProperty extends ComputedProperty {
     }
   }
 
-}
+});
 
 
 let priv = new WeakMap();

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "ember-cli-babel": "^7.1.2",
     "ember-cli-htmlbars": "^3.0.0",
     "ember-cli-version-checker": "^2.1.2",
+    "ember-compatibility-helpers": "^1.2.0",
     "ember-maybe-import-regenerator": "^0.1.5",
     "ember-named-arguments-polyfill": "^1.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4575,6 +4575,15 @@ ember-compatibility-helpers@^1.0.2, ember-compatibility-helpers@^1.1.1, ember-co
     ember-cli-version-checker "^2.1.1"
     semver "^5.4.1"
 
+ember-compatibility-helpers@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.0.tgz#feee16c5e9ef1b1f1e53903b241740ad4b01097e"
+  integrity sha512-pUW4MzJdcaQtwGsErYmitFRs0rlCYBAnunVzlFFUBr4xhjlCjgHJo0b53gFnhTgenNM3d3/NqLarzRhDTjXRTg==
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-version-checker "^2.1.1"
+    semver "^5.4.1"
+
 ember-component-css@^0.6.7:
   version "0.6.7"
   resolved "https://registry.yarnpkg.com/ember-component-css/-/ember-component-css-0.6.7.tgz#dbc6debe5c04a2c0fe8a5edc64303c7324b33945"


### PR DESCRIPTION
As mentioned in #75 I've copied the approach used in ember-concurrency.

I mostly grokked what was going on, so hopefully I didn't just blindly copy unnecessary bits.