### PR TITLE
Upgrade ember-angle-bracket-invocation-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "ember-angle-bracket-invocation-polyfill": "git+https://github.com/rwjblue/ember-angle-bracket-invocation-polyfill#f7771dc1d84764a642c769d794293d3e55dd3a6d",
+    "ember-angle-bracket-invocation-polyfill": "^1.3.0",
     "ember-cli-babel": "^7.1.2",
     "ember-cli-htmlbars": "^3.0.0",
     "ember-cli-version-checker": "^2.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4638,9 +4638,10 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
-"ember-angle-bracket-invocation-polyfill@git+https://github.com/rwjblue/ember-angle-bracket-invocation-polyfill#f7771dc1d84764a642c769d794293d3e55dd3a6d":
-  version "1.2.4"
-  resolved "git+https://github.com/rwjblue/ember-angle-bracket-invocation-polyfill#f7771dc1d84764a642c769d794293d3e55dd3a6d"
+ember-angle-bracket-invocation-polyfill@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ember-angle-bracket-invocation-polyfill/-/ember-angle-bracket-invocation-polyfill-1.3.0.tgz#2702f7102dd389f684830fbb5504ebec37febaf7"
+  integrity sha512-KD43MYtxZ0UPpT340CjassDV9SnHpiACKNy8ZXUvj1pDXY+PJgmLmrFTTON9GUQhDNwUQLfRpeSR0+k7X90lMw==
   dependencies:
     ember-cli-babel "^6.17.0"
     ember-cli-version-checker "^2.1.2"


### PR DESCRIPTION
I'm not sure if there was a specific reason for pinning to the older commit, but we had an app that has this plus another addon that pulls in the latest polyfill.  The older version won, and this caused errors with the new double-colon angle bracket syntax (`<Modal::Header>`, etc)