### PR TITLE
Safer use of htmlSafe

### DIFF
--- a/tests/dummy/app/helpers/background-image.js
+++ b/tests/dummy/app/helpers/background-image.js
@@ -1,0 +1,10 @@
+import { helper } from '@ember/component/helper';
+import { htmlSafe } from '@ember/string';
+
+export function backgroundImage([url]) {
+  // htmlSafe is justified here because encodeURI guarantees that whatever input
+  // we were given, it can't escape the url.
+  return htmlSafe(`background-image: url('${encodeURI(url)}')`);
+}
+
+export default helper(backgroundImage);

--- a/tests/dummy/app/helpers/html-safe.js
+++ b/tests/dummy/app/helpers/html-safe.js
@@ -1,8 +1,0 @@
-import { helper } from '@ember/component/helper';
-import { htmlSafe } from '@ember/string';
-
-export function docsEnabled(args) {
-  return htmlSafe(args[0]);
-}
-
-export default helper(docsEnabled);

--- a/tests/dummy/app/pods/index/demo-3/template.hbs
+++ b/tests/dummy/app/pods/index/demo-3/template.hbs
@@ -23,7 +23,7 @@
                         {{if (eq index 1) 'z-10 rotate-1 group-hover:rotate-0'}}
                         {{if (eq index 2) 'z-0 rotate-2 group-hover:rotate-0'}}
                       '
-                      style={{html-safe (concat 'background-image: url(' image ')')}}>
+                      style={{background-image image}}>
                     </div>
                   {{/animated-each}}
                 </div>
@@ -38,7 +38,7 @@
               use=(if this.staggerEnabled this.shuffleWithStagger this.shuffle)
             as |image|}}
               <div class='aspect-ratio-square bg-cover mt-6 rounded-lg shadow-md'
-                style={{html-safe (concat 'background-image: url(' image ')')}}></div>
+                style={{background-image image}}></div>
             {{/animated-each}}
           </AnimatedContainer>
         </div>

--- a/tests/dummy/app/pods/index/utils/animated-code-diff/component.js
+++ b/tests/dummy/app/pods/index/utils/animated-code-diff/component.js
@@ -4,6 +4,7 @@ import { wait } from 'ember-animated';
 import move from 'ember-animated/motions/move';
 import { fadeIn, fadeOut } from 'ember-animated/motions/opacity';
 import { highlightCode } from 'ember-cli-addon-docs/utils/compile-markdown';
+import { htmlSafe } from '@ember/string';
 
 export default Component.extend({
   init() {
@@ -107,7 +108,9 @@ function highlightLineObjects(lineObjects, language) {
   return highlightedCode.split('\n').map((text, index) => ({
     id: lineObjects[index].id,
     highlighted: lineObjects[index].highlighted,
-    text: text === "" ? "\n" : text,
+    // htmlSafe is justified here because we generated the highlighting markup
+    // ourself in highlightCode
+    text: htmlSafe(text === "" ? "\n" : text),
   }));
 }
 

--- a/tests/dummy/app/pods/index/utils/animated-code-diff/template.hbs
+++ b/tests/dummy/app/pods/index/utils/animated-code-diff/template.hbs
@@ -12,7 +12,7 @@
             use=codeTransition
             duration=400
           as |line|~}}
-            <div>{{html-safe line.text}}</div>
+            <div>{{line.text}}</div>
           {{~/animated-each~}}
         </pre>
       </AnimatedContainer>


### PR DESCRIPTION
The `htmlSafe` function can easily become a security footgun. Since the demo app exists to teach, I think it's important to exemplify the correct way to use it, even though there aren't actual security problems in the demo app since it has no authority and no private data.

The problem is that `htmlSafe` doesn't make a thing safe, it merely vouches that it's already safe.

So to use `htmlSafe` correctly, it should really be called by the same code that *makes* the string safe. In general it should be possible to look at a call to `htmlSafe` and immediately see *why* it's safe. The code that does the work of constructing the allegedly-safe string should be as close as possible to the call to `htmlSafe`.

The danger in keeping them apart is that a future refactor can easily violate the security assumptions and you can't see the problem just be examining the code that changed.