### PR TITLE
docs - fix broken animated-beacon link

### DIFF
--- a/tests/dummy/app/pods/docs/beacons/template.md
+++ b/tests/dummy/app/pods/docs/beacons/template.md
@@ -1,5 +1,5 @@
 ## Beacons
-See [animated-beacon](/docs/api/components/animated-beacon).
+See {{docs-link 'animated-beacon' 'docs.api.item' 'components/animated-beacon'}}.
 
 In this example, emails animate between Refresh (mail icon), Trash, and the Inbox. When an email gets deleted, it is a `removedSprite`. If you refresh your inbox, the new email added is an `insertedSprite`. Both the refresh button and the trash button are beacons.
 


### PR DESCRIPTION
The `animated-beacon` link on [this page](https://ember-animation.github.io/ember-animated/docs/beacons) worked locally, but not in the deployed context. It was missing the `ember-animated` segment in the rendered anchor url, `https://ember-animation.github.io/docs/api/components/animated-beacon`

Using the link helper might resolve this.