### PR TITLE
[WIP] Resize 

### DIFF
--- a/addon/-private/sprite.js
+++ b/addon/-private/sprite.js
@@ -930,7 +930,7 @@ export default class Sprite {
     this._initialBounds = shiftedBounds(this._finalBounds, dx-offsetX, dy-offsetY);
 
     if (this._inInitialPosition) {
-      // we were already moved into our priorInitiaBounds position, so we need to compensate
+      // we were already moved into our priorInitialBounds position, so we need to compensate
       this.translate(this._initialBounds.left - priorInitialBounds.left, this._initialBounds.top - priorInitialBounds.top);
     } else {
       this.translate(this._initialBounds.left - this._finalBounds.left, this._initialBounds.top - this._finalBounds.top);

--- a/addon/motions/resize.js
+++ b/addon/motions/resize.js
@@ -61,20 +61,26 @@ export class Resize extends Motion {
       }
 
       if (option != null) {
+        // User passed in option
         returnVariables[optionKey] = option;
         returnVariables[transform] = { ...this.sprite[transform], ...returnVariables[transform], [transformProp]: 1 };
       } else {
         let spriteBounds = this.sprite[bounds];
-        returnVariables[optionKey] = spriteBounds != null && spriteBounds[dimension];
+
+        if (spriteBounds != null) {
+          returnVariables[optionKey] = spriteBounds[dimension]
+        } else {
+          // If the sprite has no `initialBounds` or `finalBounds` key, then we use alternate bounds value
+          // This results in the same start and end attribute, meaning the that the sprite won't animate on that plane
+          let alternateBounds = bounds === 'initialBounds' ? 'finalBounds' : 'initialBounds'
+          returnVariables[optionKey] = this.sprite[alternateBounds][dimension]
+        }
         returnVariables[transform] = { ...this.sprite[transform], ...returnVariables[transform] };
       }
     });
 
     return returnVariables;
   }
-
-
-
 
   * animate() {
     let sprite = this.sprite;
@@ -83,31 +89,23 @@ export class Resize extends Motion {
       finalCumulativeTransform } = this._extractHeightAndWidthOpts();
 
     if (!this.prior) {
-      this.widthTween = (fromWidth === false || toWidth === false)
-        ? { done: true }
-        : new Tween(
+      this.widthTween =  new Tween(
           fromWidth / initialCumulativeTransform.a,
           toWidth / finalCumulativeTransform.a, duration
         );
 
-      this.heightTween = (fromHeight === false || toHeight === false)
-        ? { done: true }
-        : new Tween(
+      this.heightTween = new Tween(
           fromHeight / initialCumulativeTransform.d,
           toHeight / finalCumulativeTransform.d, duration
         );
     } else {
-      this.widthTween = (toWidth === false)
-        ? { done: true}
-        : new Tween(
+      this.widthTween = new Tween(
           0,
           toWidth / finalCumulativeTransform.a - this.prior.sprite.finalBounds.width,
           duration
         ).plus(this.prior.widthTween);
 
-      this.heightTween = (toHeight === false)
-      ? { done: true }
-      : new Tween(
+      this.heightTween = new Tween(
           0,
           toHeight / finalCumulativeTransform.d - this.prior.sprite.finalBounds.height,
           duration

--- a/tests/integration/components/animated-if-test.js
+++ b/tests/integration/components/animated-if-test.js
@@ -2,6 +2,8 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { setupAnimationTest, time, animationsSettled, bounds as _bounds } from 'ember-animated/test-support';
+import resize from 'ember-animated/motions/resize';
 
 module('Integration | Component | animated if', function(hooks) {
   setupRenderingTest(hooks);
@@ -34,5 +36,48 @@ module('Integration | Component | animated if', function(hooks) {
       {{/animated-if}}
     `);
     assert.ok(this.element.querySelector('.falsey'));
+  });
+});
+
+module('Integration | Component | animated if', function(hooks) {
+  setupRenderingTest(hooks);
+  setupAnimationTest(hooks);
+
+  function *transition({ insertedSprites, removedSprites, keptSprites }) {
+    insertedSprites.forEach(sprite => {
+      resize(sprite, { fromHeight: 0 });
+    });
+    removedSprites.forEach(sprite => {
+      resize(sprite, { toHeight: 0 });
+    });
+    keptSprites.forEach(sprite => {
+       // this one needs no args because it already has a natural
+       // initial and final size. This case comes up if you interrupt
+       // a running animation.
+       resize(sprite);
+    });
+  }
+
+  test('can be used to resize elements that do not exist in the DOM when false', async function(assert) {
+    this.set('transition', transition)
+    await this.render(hbs`
+      <AnimatedContainer>
+        {{#animated-if showThing use=transition duration=5000}}
+          <div style="overflow-y: hidden">Content</div>
+        {{/animated-if}}
+      </AnimatedContainer>
+    `);
+
+    await animationsSettled();
+    let start = _bounds(this.element.querySelector('.animated-container'));
+    time.pause();
+    this.set('showThing', true);
+    // todo: test pauses indefinitely on this and fails. If this line is removed, the "Content" seems to never appear
+    await animationsSettled();
+    await time.advance(500);
+    let midpoint = _bounds(this.element.querySelector('.animated-container'));
+    await time.advance(500);
+    let end = _bounds(this.element.querySelector('.animated-container'));
+    assert(start.height < midpoint.height && midpoint.height < end.height);
   });
 });


### PR DESCRIPTION
A WIP PR to address #113 
The issue here is that when wrapping a resize motion in an animated-if transition, the sprite either starts or ends without initialBounds/finalBounds. This PR allows the caller to provide some initial/final height/width values to act in place of calculated bounds.

I'd really appreciate and feedback on the approach here, as it to my eyes it looks a bit clunky. There might be a cleaner way to do this, so I'm definitely open to feedback.

## TODO:
* [ ] Write tests
* [ ] Update docs with options (probably separate PR into gh-pages branch)
