### PR TITLE
don't serialize identity transform as "none"

### DIFF
--- a/addon/-private/transform.js
+++ b/addon/-private/transform.js
@@ -26,9 +26,6 @@ export default class Transform {
     this.ty = ty;
   }
   serialize() {
-    if (this.isIdentity()) {
-      return 'none';
-    }
     return `matrix(${this.a}, ${this.b}, ${this.c}, ${this.d}, ${this.tx}, ${this.ty})`;
   }
 


### PR DESCRIPTION
Having no transform is different from having an identity transform, because the presence of a transform (even the identity) has side-effects like creating a new stacking context, altering the behavior of fixed positioned children, etc.