### PR TITLE
Add new angle bracket polyfill version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "ember-angle-bracket-invocation-polyfill": "^1.3.0",
+    "ember-angle-bracket-invocation-polyfill": "^1.3.0 || ^2.0.0",
     "ember-cli-babel": "^7.7.3",
     "ember-cli-htmlbars": "^3.0.1",
     "ember-cli-version-checker": "^2.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4660,14 +4660,15 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
-ember-angle-bracket-invocation-polyfill@^1.3.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/ember-angle-bracket-invocation-polyfill/-/ember-angle-bracket-invocation-polyfill-1.3.1.tgz#3dd0b91b3776a8048a943889c031fa7f9ea44ec4"
-  integrity sha512-eeE4LBFIxJ5EclTIydPMPs04vvSDv64m+1fxwN2UKdSdRDWwus36k4B/LquDfWuG1WI0Dk3R4WoTFcRYlbNTWg==
+"ember-angle-bracket-invocation-polyfill@^1.3.0 || ^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ember-angle-bracket-invocation-polyfill/-/ember-angle-bracket-invocation-polyfill-2.0.2.tgz#117ab5238305f11046a2eb3a5bc026c98d2cf5c1"
+  integrity sha512-HkG0xyTHtAhWVjU0Q5V/i4xe4FRvNIOaiUEgIvN815F3TIUboV/J0xhYgivm0uDZp9lAYUVF+U5PI1sCnlC3Og==
   dependencies:
     ember-cli-babel "^6.17.0"
     ember-cli-version-checker "^2.1.2"
     ember-compatibility-helpers "^1.0.2"
+    silent-error "^1.1.1"
 
 ember-animated-tools@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Looks like version 2.0 ember-angle-bracket-invocation-polyfill has been released. Is this the best way to say ember-animated works with 1.3 and 2.0?