### PR TITLE
fix classlist cleanup

### DIFF
--- a/addon/-private/sprite.js
+++ b/addon/-private/sprite.js
@@ -141,7 +141,6 @@ export default class Sprite {
       // so inheriting the state from our predecessor is important for
       // correctness.
       this._styleCache = predecessor._styleCache;
-      this._classListCache = predecessor._classListCache;
       this._parentElement = predecessor._parentElement;
       this._revealed = predecessor._revealed;
       this._imposedStyle = predecessor._imposedStyle;
@@ -152,7 +151,6 @@ export default class Sprite {
       }
     } else {
       this._styleCache = null;
-      this._classListCache = null;
       this._parentElement = null;
       this._revealed = null;
       this._imposedStyle = null;
@@ -411,7 +409,8 @@ export default class Sprite {
         left: style.left,
         bottom: style.bottom,
         right: style.right,
-        transform: style.transform
+        transform: style.transform,
+        classList: Array.from(this.element.classList),
       };
     }
   }
@@ -444,6 +443,15 @@ export default class Sprite {
       style.right = pos.right;
       style.bottom = pos.bottom;
       style.transform = pos.transform;
+
+      for (let cls of pos.classList) {
+        this.element.classList.add(cls);
+      }
+      for (let cls of Array.from(this.element.classList)) {
+        if (!pos.classList.includes(cls)) {
+          this.element.classList.remove(cls);
+        }
+      }
     }
   }
 
@@ -668,7 +676,6 @@ export default class Sprite {
       cache[property] = style[property];
     });
     this._styleCache = cache;
-    this._classListCache = Array.from(this.element.classList);
   }
 
   lock() {
@@ -696,14 +703,6 @@ export default class Sprite {
     this._reapplyPosition(this._finalPosition);
 
     this._clearMarginCollapse();
-    for (let cls of this._classListCache) {
-      this.element.classList.add(cls);
-    }
-    for (let cls of Array.from(this.element.classList)) {
-      if (!this._classListCache.includes(cls)) {
-        this.element.classList.remove(cls);
-      }
-    }
   }
 
 


### PR DESCRIPTION
#143 introduced a bug. It restores the *initial* classlist after animation, but it should restore the *final* classlist (because of course classes could be legitimately changed by ember between the two).