### PR TITLE
fix alpha premultiplication bug

### DIFF
--- a/addon/color.js
+++ b/addon/color.js
@@ -34,12 +34,12 @@ export class ColorTween {
     this.aTween = new Tween(initialColor.a, finalColor.a, duration, easing);
   }
   get currentValue() {
-    let currentAlpha = this.aTween.currentValue || 1;
+    let nonZeroAlpha = this.aTween.currentValue || 1;
     return new Color({
-      r: Math.floor(this.rTween.currentValue / currentAlpha),
-      g: Math.floor(this.gTween.currentValue / currentAlpha),
-      b: Math.floor(this.bTween.currentValue / currentAlpha),
-      a: currentAlpha,
+      r: Math.floor(this.rTween.currentValue / nonZeroAlpha),
+      g: Math.floor(this.gTween.currentValue / nonZeroAlpha),
+      b: Math.floor(this.bTween.currentValue / nonZeroAlpha),
+      a: this.aTween.currentValue,
     });
   }
   get done() {


### PR DESCRIPTION
At zero alpha we were flashing the wrong color because even though we need to not *divide* by alpha, we still need the true alpha in the output color.