### PR TITLE
Add missing semicolon to example

### DIFF
--- a/addon/transitions/fade.js
+++ b/addon/transitions/fade.js
@@ -4,7 +4,7 @@ import opacity from 'ember-animated/motions/opacity';
   Fades inserted, removed, and kept sprites.
 
   ```js
-  import fade from 'ember-animated/transitions/fade'
+  import fade from 'ember-animated/transitions/fade';
 
   export default Component.extend({
     transition: fade


### PR DESCRIPTION
Adds a missing semicolon to [the fade transition example in the docs](https://ember-animation.github.io/ember-animated/docs/api/modules/ember-animated/transitions/fade).