### PR TITLE
Fix fastboot

### DIFF
--- a/addon/element-remove.ts
+++ b/addon/element-remove.ts
@@ -1,5 +1,11 @@
 // Polyfill Element.remove on IE11
 // from:https://github.com/jserz/js_piece/blob/master/DOM/ChildNode/remove()/remove().md
+
+const classPrototypes =
+  [window.Element, window.CharacterData,window.DocumentType]
+    .filter( (klass) => klass )
+    .map( (klass) => klass.prototype );
+
 (function(arr) {
   arr.forEach(function(item) {
     if (Object.prototype.hasOwnProperty.call(item, 'remove')) {
@@ -14,4 +20,4 @@
       },
     });
   });
-})([Element.prototype, CharacterData.prototype, DocumentType.prototype]);
+})(classPrototypes);

--- a/addon/element-remove.ts
+++ b/addon/element-remove.ts
@@ -1,6 +1,12 @@
 // Polyfill Element.remove on IE11
 // from:https://github.com/jserz/js_piece/blob/master/DOM/ChildNode/remove()/remove().md
 
+interface Window {
+  Element: any;
+  CharacterData: any;
+  DocumentType: any;
+}
+
 const classPrototypes =
   [window.Element, window.CharacterData,window.DocumentType]
     .filter( (klass) => klass )

--- a/addon/element-remove.ts
+++ b/addon/element-remove.ts
@@ -7,10 +7,13 @@ interface Window {
   DocumentType: any;
 }
 
-const classPrototypes =
-  [window.Element, window.CharacterData,window.DocumentType]
-    .filter( (klass) => klass )
-    .map( (klass) => klass.prototype );
+const classPrototypes = [
+  window.Element,
+  window.CharacterData,
+  window.DocumentType,
+]
+  .filter(klass => klass)
+  .map(klass => klass.prototype);
 
 (function(arr) {
   arr.forEach(function(item) {


### PR DESCRIPTION
FastBoot does not have the concept of Element, CharacterData and presumably DocumentType.  Inclusion of this polyfill thus makes FastBoot crash early.

If you want to update this PR, feel free to push on the branch.
Some further notes on this PR:

## Check for existence

Implementation currently checks whether the either of these three entities exist and executes the polyfill for any of those that do.  Alternatively, a check on IE11 could have been placed.  Current implementation seems more flexible in the long run, though it might make phasing out the polyfill harder.

## Use of window

We now check whether the entity exists on the window instance.  For clarity, we'd have preferred to check for the existence of Element as a global, yet TypeScript doesn't seem to let us.

The use of Window circumvents the TypeScript error, but it creates a new warning.  As is clear, I'm not a TypeScript expert by far.  I based myself https://mariusschulz.com/blog/declaring-global-variables-in-typescript#augmenting-the-window-interface and https://www.typescriptlang.org/docs/handbook/declaration-merging.html#merging-interfaces for the solution.  The interface is merged together and thus does not overrule any existing window interface.

## Tests

I've ran the test-cases on my machine using Chromium (instead of Chrome) and I've verified FastBoot does not throw an error in our app anymore.  It would be nice if someone could double-check IE11 still works now.  I don't have it on hand.