### PR TITLE
Support receivedSprites in moveOver

### DIFF
--- a/addon/transitions/move-over.js
+++ b/addon/transitions/move-over.js
@@ -56,6 +56,8 @@ export default function* moveOver(dimension, direction, context) {
     viewport = context.insertedSprites[0].finalBounds;
   } else if (context.keptSprites.length) {
     viewport = context.keptSprites[0].finalBounds;
+  } else if (context.receivedSprites.length) {
+    viewport = context.receivedSprites[0].finalBounds;
   } else {
     throw new Error('Unimplemented');
   }
@@ -94,6 +96,12 @@ export default function* moveOver(dimension, direction, context) {
     }
   } else if (context.keptSprites.length) {
     let move = new Move(context.keptSprites[0]);
+    move.run();
+    context.removedSprites.forEach(sprite => {
+      follow(sprite, { source: move });
+    });
+  } else if (context.receivedSprites.length) {
+    let move = new Move(context.receivedSprites[0]);
     move.run();
     context.removedSprites.forEach(sprite => {
       follow(sprite, { source: move });


### PR DESCRIPTION
This pull request fixes at least one case where you can get the Unimplemented error from the moveOver transition. Specifically, we saw this happen when performing a moveOver transition while doing a route transition. Adding support for receivedSprites fixed our issue locally.

This should help address https://github.com/ember-animation/ember-animated/issues/208