### PR TITLE
Run GitHub Actions CI on pull request

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -38,7 +38,7 @@ jobs:
     - name: typecheck
       run: yarn typecheck
     - name: tests
-      run: yarn test
+      run: yarn test:ember
 
   docs:
     name: "Docs"

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,8 @@
 name: Node CI
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -88,7 +88,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        try-scenario: [ember-lts-3.8, ember-lts-3.12, ember-release, ember-beta, ember-canary, ember-default-with-jquery, ember-classic]
+        try-scenario:
+          - ember-lts-3.8
+          - ember-lts-3.12
+          - ember-lts-3.16
+          - ember-lts-3.20
+          - ember-release
+          - ember-beta
+          - ember-canary
+          - ember-default-with-jquery
+          - ember-classic
     steps:
     - uses: actions/checkout@v1
     - name: Install node

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -31,6 +31,14 @@ module.exports = async function() {
         },
       },
       {
+        name: 'ember-lts-3.20',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.20.5',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {

--- a/tests/unit/move-test.js
+++ b/tests/unit/move-test.js
@@ -183,7 +183,7 @@ module('Unit | Move', function(hooks) {
     s.lock();
 
     let motion = new Move(s, {
-      easing: (v) => v < 0.5 ? -v : 2 - v
+      easing: v => (v < 0.5 ? -v : 2 - v),
     });
 
     tester.run(motion, { duration: 400 });


### PR DESCRIPTION
Noticed that CI does not run for pull requests from fork, examples #243, #221, #238.