### PR TITLE
Make explicit copy of reference to Date

### DIFF
--- a/addon/-private/concurrency-helpers.ts
+++ b/addon/-private/concurrency-helpers.ts
@@ -125,10 +125,12 @@ export function afterRender() {
   return promise;
 }
 
+// Prevents sinon fake timers from interfering with the clock.
+const _Date = Date;
 // This provides a unified place to hook into time control for testing.
 export let clock = {
   now() {
-    return new Date().getTime();
+    return new _Date().getTime();
   },
 };
 


### PR DESCRIPTION
This should prevent interference from sinon fake timers causing animations to not run correctly in tests in certain cases.