### PR TITLE
Strict property initialization error in ember-release

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
     "strict": true,
+    "strictPropertyInitialization": false,
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
Just getting the tests to run to play around with a solution.  I don't think we want to actually turn this off.

```
- message: ember-animated/components/animated-beacon.ts: /home/runner/work/luna/luna/ember-animated/components/animated-beacon.ts: Definietly assigned fields and fields with the 'declare' modifier cannot be initialized here, but only in the constructor
 ```