### PR TITLE
Widen `ember-angle-bracket-invocation-polyfill` dependency requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "assert-never": "^1.2.0",
-    "ember-angle-bracket-invocation-polyfill": "^1.3.0 || ^2.0.0",
+    "ember-angle-bracket-invocation-polyfill": "^1.3.0 || ^2.0.0 || ^3.0.1",
     "ember-auto-import": "^1.12.0",
     "ember-cli-babel": "^7.21.0",
     "ember-cli-htmlbars": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6821,12 +6821,12 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
-"ember-angle-bracket-invocation-polyfill@^1.3.0 || ^2.0.0":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/ember-angle-bracket-invocation-polyfill/-/ember-angle-bracket-invocation-polyfill-2.0.2.tgz#117ab5238305f11046a2eb3a5bc026c98d2cf5c1"
-  integrity sha512-HkG0xyTHtAhWVjU0Q5V/i4xe4FRvNIOaiUEgIvN815F3TIUboV/J0xhYgivm0uDZp9lAYUVF+U5PI1sCnlC3Og==
+"ember-angle-bracket-invocation-polyfill@^1.3.0 || ^2.0.0 || ^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ember-angle-bracket-invocation-polyfill/-/ember-angle-bracket-invocation-polyfill-3.0.1.tgz#d346692bd75489e49af95e6727b2817d839f7f22"
+  integrity sha512-zxG6yazA7X9+itp3rir+aK6h+NDRJ/COgFmMWgY+Ol8z81MVj5+tgB4ZXDz7e8cCM0S6cUwv82rC6Bb/P7K0ow==
   dependencies:
-    ember-cli-babel "^6.17.0"
+    ember-cli-babel "^7.0.0"
     ember-cli-version-checker "^2.1.2"
     ember-compatibility-helpers "^1.0.2"
     silent-error "^1.1.1"
@@ -6895,7 +6895,7 @@ ember-cli-babel-plugin-helpers@^1.1.1:
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
   integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.11.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.17.0, ember-cli-babel@^6.4.1, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.11.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.4.1, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==


### PR DESCRIPTION
This change will allow apps to use the v3.0.0 release of `ember-angle-bracket-invocation-polyfill` instead of the older v1.x or v2.x series.

The requirement is widened so that ember-cli-dependency-lint is not causing issues in case apps still use addons that require the v0.1.x release.

Similar to #267 by @Turbo87.

Additionally, v3.0.0 of `ember-angle-bracket-invocation-polyfill` upgrades ember-cli-babel to v7 so another instance of ember-cli-babel@6 will go away with this upgrade.

Also v3.0.0 of `ember-angle-bracket-invocation-polyfill` drops Node < 10 support but `ember-animated` already requires Node.js v10 or above.