### PR TITLE
Fix TypeScript types paths

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -98,6 +98,19 @@
       "./services/-ea-motion.js": "./dist/_app_/services/-ea-motion.js"
     }
   },
+  "typesVersions": {
+    "*": {
+      ".": [
+        "./dist/index.d.ts"
+      ],
+      "*": [
+        "./dist/*"
+      ],
+      "test-support": [
+        "./dist/test-support/index.d.ts"
+      ]
+    }
+  },
   "volta": {
     "extends": "../package.json"
   }


### PR DESCRIPTION
As part of 1.0 addon was migrated to v2 and TypeScript compilation/publishing process has changed from using `ember-cli-typescript` to babel + typescript.

This PR updates `exports` and `typesVersions` fields in `package.json` of the addon for propeer types expliration by consuming apps and addons.