### PR TITLE
Fix compatibility with ember-element-helper@0.6.1

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.5.0",
+    "@embroider/macros": "^1.5.0",
     "assert-never": "^1.2.1",
     "ember-element-helper": "^0.5.0 || ^0.6.0"
   },

--- a/addon/src/components/animated-container.hbs
+++ b/addon/src/components/animated-container.hbs
@@ -1,8 +1,19 @@
-{{!--
-  The @class is only there to support a deprecated usage.
---}}
-{{#let (component (ensure-safe-component (-element this.tag)) tagName=this.tag) as |Tag|~}}
-  <Tag class="animated-container {{@class}}" ...attributes >
-    {{yield}}
-  </Tag>
-{{/let}}
+{{#if this.useElementHelper}}
+  {{!--
+    The @class is only there to support a deprecated usage.
+  --}}
+  {{#let (element this.tag) as |Tag|~}}
+    <Tag class="animated-container {{@class}}" ...attributes>
+      {{yield}}
+    </Tag>
+  {{/let}}
+{{else}}
+  {{!--
+    The @class is only there to support a deprecated usage.
+  --}}
+  {{#let (component (ensure-safe-component (-element this.tag)) tagName=this.tag) as |Tag|~}}
+    <Tag class="animated-container {{@class}}" ...attributes>
+      {{yield}}
+    </Tag>
+  {{/let}}
+{{/if}}

--- a/addon/src/components/animated-container.ts
+++ b/addon/src/components/animated-container.ts
@@ -2,6 +2,7 @@ import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { alias } from '@ember/object/computed';
 import { action } from '@ember/object';
+import { dependencySatisfies } from '@embroider/macros';
 import { Resize } from '../motions/resize';
 import { task, type Task } from '../-private/ember-scheduler';
 import Sprite from '../-private/sprite';
@@ -199,4 +200,8 @@ export default class AnimatedContainerComponent extends Component {
     this.sprite = null;
   }).restartable()
   animate!: Task;
+
+  get useElementHelper() {
+    return dependencySatisfies('ember-element-helper', '^0.6.1');
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,7 @@ importers:
       '@babel/preset-typescript': ^7.16.7
       '@embroider/addon-dev': ^1.5.0
       '@embroider/addon-shim': ^1.5.0
+      '@embroider/macros': ^1.5.0
       '@glimmer/env': ^0.1.7
       '@rollup/plugin-babel': ^5.3.1
       '@types/ember': ^4.0.0
@@ -51,6 +52,7 @@ importers:
       typescript: ^4.6.3
     dependencies:
       '@embroider/addon-shim': 1.5.0
+      '@embroider/macros': 1.5.0
       assert-never: 1.2.1
       ember-element-helper: 0.6.0
     devDependencies:
@@ -11551,6 +11553,7 @@ packages:
   /lru-cache/7.7.3:
     resolution: {integrity: sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==}
     engines: {node: '>=12'}
+    deprecated: Please update to latest patch version to fix memory leak https://github.com/isaacs/node-lru-cache/issues/227
 
   /lunr/2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}

--- a/test-app/tests/integration/components/animated-container-test.js
+++ b/test-app/tests/integration/components/animated-container-test.js
@@ -579,8 +579,8 @@ module(
 
     test('accepts a custom tag', async function (assert) {
       await render(hbs`
-      <AnimatedContainer @tag="section"/>
-    `);
+        <AnimatedContainer @tag="section"/>
+      `);
 
       let elt = find('.animated-container');
       assert.strictEqual(elt.tagName, 'SECTION');


### PR DESCRIPTION
Closes #450

`ember-element-helper@0.6.1` has renamed template helpers from `-element` to `element` and removed an AST transform that was doing helpers rename at build time.

That AST transform was inert because `ember-animated` was converted to v2 addon and AST transform do not automatically picked up and there is no simple and straightforward way of using it. Hence `ember-animated@1.0.0` was using `-element` helper instead of `element`.

This PR makes `ember-animated` compatible both forward and backward with v0.5.x and v0.6.x versions of `ember-element-helper`