### PR TITLE
Make TransitionContext type export public

### DIFF
--- a/addon/src/index.ts
+++ b/addon/src/index.ts
@@ -30,3 +30,4 @@ export { continueMotions } from './-private/motion-bridge';
 export { default as Tween } from './-private/tween';
 
 export type { default as Sprite } from './-private/sprite';
+export type { default as TransitionContext } from './-private/transition-context';

--- a/addon/src/transitions/fade.ts
+++ b/addon/src/transitions/fade.ts
@@ -1,4 +1,4 @@
-import type TransitionContext from 'src/-private/transition-context';
+import type TransitionContext from '../-private/transition-context';
 import opacity from '../motions/opacity';
 
 /**


### PR DESCRIPTION
Allows to type the argument received by the custom transition.

Closes #443 cc @kpfefferle