### PR TITLE
Replace use of RSVP with native Promise

### DIFF
--- a/addon/src/-private/concurrency-helpers.ts
+++ b/addon/src/-private/concurrency-helpers.ts
@@ -1,20 +1,9 @@
 import { schedule, cancel } from '@ember/runloop';
-import { warn } from '@ember/debug';
-import RSVP from 'rsvp';
 import type { EmberRunTimer } from '@ember/runloop/types';
 import { getOrCreate as _getOrCreate } from './singleton';
 
 function getOrCreate<T>(key: string, construct: () => T): T {
   return _getOrCreate(`concurrency-helpers.${key}`, construct);
-}
-
-if (!(window as any).Promise) {
-  warn(
-    'Unable to achieve proper rAF timing on this browser, microtask-based Promise implementation needed.',
-    false,
-    { id: 'ember-animated-missing-microtask' },
-  );
-  window.Promise = RSVP.Promise as any as PromiseConstructor;
 }
 
 interface iFrameState {
@@ -103,10 +92,10 @@ export function microwait(): Promise<void> {
   return new Promise((resolve) => resolve());
 }
 
-export function wait(ms = 0) {
+export function wait(ms = 0): Promise<void> {
   if (clock.now === originalClock) {
     let ticket: number;
-    let promise = new RSVP.Promise((resolve) => {
+    let promise = new Promise<void>((resolve) => {
       ticket = window.setTimeout(resolve, ms);
     });
     registerCancellation(promise, () => {
@@ -116,7 +105,7 @@ export function wait(ms = 0) {
   } else {
     let canceled = false;
     let started = clock.now();
-    let promise = new RSVP.Promise((resolve) => {
+    let promise = new Promise<void>((resolve) => {
       function checkIt() {
         if (!canceled) {
           if (clock.now() - started > ms) {

--- a/addon/src/-private/ember-scheduler.ts
+++ b/addon/src/-private/ember-scheduler.ts
@@ -1,4 +1,3 @@
-import { Promise as EmberPromise } from 'rsvp';
 import { join, scheduleOnce } from '@ember/runloop';
 import { addObserver } from '@ember/object/observers';
 import { computed, set } from '@ember/object';
@@ -268,5 +267,5 @@ function* withRunLoop(generator: Generator): Generator {
 }
 
 export function timeout(ms: number) {
-  return new EmberPromise((resolve) => setTimeout(resolve, ms));
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
 }

--- a/addon/src/test-support/index.js
+++ b/addon/src/test-support/index.js
@@ -1,5 +1,4 @@
 import { importSync } from '@embroider/macros';
-import { resolve } from 'rsvp';
 import { run } from '@ember/runloop';
 import { Color } from '../color';
 import { relativeBounds } from '../-private/bounds';
@@ -27,7 +26,7 @@ export function animationsSettled() {
   run(() => {
     idle = owner.lookup('service:-ea-motion').get('waitUntilIdle').perform();
   });
-  return resolve(idle);
+  return Promise.resolve(idle);
 }
 
 // This is like getBoundingClientRect, but it is relative to the


### PR DESCRIPTION
It looks like there is no need to use RSVP anymore and all the usages are straightforward conversion to native promise.

Would like hear from @ef4 on this just in case I'm missing something.