### PR TITLE
Allow multiple beacons with the same name

### DIFF
--- a/addon/src/components/animated-beacon.ts
+++ b/addon/src/components/animated-beacon.ts
@@ -105,6 +105,14 @@ export default class AnimatedBeacon extends Component {
   }
 
   @task(function* (this: AnimatedBeacon) {
+    if (!this.name) {
+      throw new Error('Beacons must have a name.');
+    }
+
+    if (this.motionService.hasBeacon(this.name)) {
+      return;
+    }
+
     let element = this._firstChildElement();
     if (!element) {
       return;

--- a/addon/src/services/-ea-motion.ts
+++ b/addon/src/services/-ea-motion.ts
@@ -240,14 +240,14 @@ export default class MotionService extends Service {
     }
   }
 
+  hasBeacon(name: string) {
+    return this._beacons?.[name];
+  }
+
   @task(function* (this: MotionService, name: string, beacon: Sprite) {
     if (!this._beacons) {
       this._beacons = {};
     }
-    if (this._beacons[name]) {
-      throw new Error(`There is more than one beacon named "${name}"`);
-    }
-
     this._beacons[name] = beacon;
     // allows other farMatches to start
     yield microwait();

--- a/test-app/tests/integration/components/animated-beacon-test.js
+++ b/test-app/tests/integration/components/animated-beacon-test.js
@@ -28,6 +28,30 @@ module('Integration | Component | animated-beacon', function (hooks) {
     await animationsSettled();
   });
 
+  test('beacons are available in transitions when multiple animated components are present', async function (assert) {
+    assert.expect(1);
+    this.set('transition', function* ({ beacons }) {
+      assert.ok(beacons.thegroup, 'expected one beacon');
+    });
+
+    await render(hbs`
+{{#animated-beacon name="thegroup"}}
+  <div class="alpha"></div>
+{{/animated-beacon}}
+
+{{#animated-value this.showIt use=this.transition }}
+  <div class="beta"></div>
+{{/animated-value}}
+{{#animated-value this.showIt use=this.transition }}
+  <div class="theta"></div>
+{{/animated-value}}
+`);
+
+    this.set('showIt', true);
+    await settled();
+    await animationsSettled();
+  });
+
   test('it picks up correct bounds', async function (assert) {
     assert.expect(4);
 

--- a/test-app/tests/integration/components/animated-beacon-test.js
+++ b/test-app/tests/integration/components/animated-beacon-test.js
@@ -29,9 +29,13 @@ module('Integration | Component | animated-beacon', function (hooks) {
   });
 
   test('beacons are available in transitions when multiple animated components are present', async function (assert) {
-    assert.expect(1);
-    this.set('transition', function* ({ beacons }) {
-      assert.ok(beacons.thegroup, 'expected one beacon');
+    assert.expect(2);
+    this.set('transition1', function* ({ beacons }) {
+      assert.ok(beacons.thegroup, '1st transition expected a beacon');
+    });
+
+    this.set('transition2', function* ({ beacons }) {
+      assert.ok(beacons.thegroup, '2nd transition expected a beacon');
     });
 
     await render(hbs`
@@ -39,10 +43,10 @@ module('Integration | Component | animated-beacon', function (hooks) {
   <div class="alpha"></div>
 {{/animated-beacon}}
 
-{{#animated-value this.showIt use=this.transition }}
+{{#animated-value this.showIt use=this.transition1 }}
   <div class="beta"></div>
 {{/animated-value}}
-{{#animated-value this.showIt use=this.transition }}
+{{#animated-value this.showIt use=this.transition2 }}
   <div class="theta"></div>
 {{/animated-value}}
 `);


### PR DESCRIPTION
This addresses https://github.com/ember-animation/ember-animated/issues/225

First commit I added a failing test that just had a beacon and two animated-ifs.  That test fails like the bug describes.

After diving into the code a bit I feel that this assertion was put here in error.  As the added test shows, when multiple animated components are present the beacon will [add itself](https://github.com/ember-animation/ember-animated/blob/master/addon/src/components/animated-beacon.ts#L121) to the -ea-motion service once per new animation. 
 This is because the beacons are [listening to all animations](https://github.com/ember-animation/ember-animated/blob/master/addon/src/components/animated-beacon.ts#L78).  The original authors didn't cover the case when multiple animations would start in the same cycle, i.e. when more than one animated component gets rendered on the page.

I added a `hasBeacon` method so that the Beacon component can return early if it's already added itself to the service.  

The problem the original author tried to help with, warning when devs add two similar named beacons, is tough to crack with this implementation.  I think its better to just fix this error and fore-go the warning.  

One thing to note, the original error didn't really impede animations.  Throwing an error would effective cause the `addBeacon` task to exit early and the sprite never got updated.  
