### PR TITLE
Publish to npm from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,3 +160,36 @@ jobs:
       - name: Type checking
         run: tsc --noEmit
         working-directory: addon
+
+  publish:
+    name: Publish
+    needs: [test-library]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 6.x
+
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 12.x
+          cache: 'pnpm'
+          # This creates an .npmrc that reads the NODE_AUTH_TOKEN environment variable
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      # We need a workspace aware version of npm because our addon is in a subdir but our .npmrc is in the root
+      - name: npm8
+        run: npm install -g npm@8
+
+      - name: npm publish
+        run: npm publish --tag=latest --verbose --workspace=addon
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/.github/workflows/publish-unstable.yml
+++ b/.github/workflows/publish-unstable.yml
@@ -20,6 +20,7 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 6.x
+
       - name: Install Node
         uses: actions/setup-node@v3
         with:
@@ -27,14 +28,18 @@ jobs:
           cache: 'pnpm'
           # This creates an .npmrc that reads the NODE_AUTH_TOKEN environment variable
           registry-url: 'https://registry.npmjs.org'
+
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
+
       # We need a workspace aware version of npm because our addon is in a subdir but our .npmrc is in the root
       - name: npm8
         run: npm install -g npm@8
+
       - name: set version
         run: npm version --no-git-tag-version --workspaces-update=false `node -e "console.log(require('./package.json').version)"`-unstable.`git rev-parse --short HEAD`
         working-directory: addon
+
       - name: npm publish
         run: npm publish --tag=unstable --verbose --workspace=addon
         env:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,9 +30,9 @@ Once the prep work is completed, the actual release is straight forward:
 
 * First, ensure that you have installed your projects dependencies:
 
-```sh
-pnpm install
-```
+  ```sh
+  pnpm install
+  ```
 
 * Second, ensure that you have obtained a
   [GitHub personal access token][generate-token] with the `repo` scope (no
@@ -45,16 +45,21 @@ pnpm install
   export GITHUB_AUTH=abc123def456
   ```
 
-[generate-token]: https://github.com/settings/tokens/new?scopes=repo&description=GITHUB_AUTH+env+variable
+  [generate-token]: https://github.com/settings/tokens/new?scopes=repo&description=GITHUB_AUTH+env+variable
 
 * And last (but not least 😁) do your release.
 
-```sh
-pnpm run release
-```
+  ```sh
+  pnpm run release
+  ```
 
 [release-it](https://github.com/release-it/release-it/) manages the actual
 release process. It will prompt you to choose the version number after which
 you will have the chance to hand tweak the changelog to be used (for the
 `CHANGELOG.md` and GitHub release), then `release-it` continues on to tagging,
 pushing the tag and commits, etc.
+
+## Unstable Tag
+
+For every push to the master branch, [`Publish Unstable`](./.github/workflows/publish-unstable.yml)
+publishes an NPM package to the "unstable" NPM tag.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "launchEditor": false
       },
       "release-it-yarn-workspaces": {
+        "publish": false,
         "workspaces": [
           "addon"
         ],


### PR DESCRIPTION
@ef4 this setup would allow to publish to npm from CI reducing manual work.

Follows setup you did for `publish-unstable` workflow.