### PR TITLE
Update docs to use and recommend inline-block

### DIFF
--- a/docs/app/styles/app.scss
+++ b/docs/app/styles/app.scss
@@ -231,7 +231,8 @@
   background-color: lightskyblue;
 }
 
-.scenario-rules span {
+.scenario-rules .count {
+  display: inline-block;
   border: 1px solid blue;
 }
 
@@ -370,6 +371,10 @@
 }
 
 /* BEGIN-SNIPPET moving-word-snippet.css */
+.moving-word span {
+  display: inline-block;
+}
+
 .moving-word-demo button {
   font-weight: bold;
   border: 2px solid rgb(7, 170, 219);

--- a/docs/app/templates/docs/rules.md
+++ b/docs/app/templates/docs/rules.md
@@ -4,6 +4,8 @@
 
 In this demonstration, the `rules` choose a transition based on the number in the counter. When the counter increments, the new number is larger than the old number so the `toUp` transition runs. When the counter decrements, the old number is larger than the new one and and the `toDown` transition runs. 
 
+> NOTE: When elements are animated, they are absolutely positioned, which implies `display: block`. If you are attempting to animate an inline element, there will be a slight visual "jump" when switching between inline and block displays.  Therefore, when using any of the animators &mdash; like `{{animated-value}}` used here &mdash; the animated children should not be `display: inline`.  In this demo, `count` is `display: inline-block`.
+
 <DocsDemo as |demo|>
   <demo.example>
     <RulesExample />


### PR DESCRIPTION
It's [a known bug](https://github.com/ember-animation/ember-animated/issues/120) that animating inline elements does not work very well.  The [recommended workaround](https://github.com/ember-animation/ember-animated/issues/124) is to use block elements instead.

This tiny PR updates two demos in the docs app to use `display: inline-block` for animated spans and avoids the visual "jump" in the animations.

### Before - data-dependent

![before2](https://github.com/ember-animation/ember-animated/assets/142243/35d4016f-4c19-4d59-b614-e43025b29392)

### After - data-dependent

![after2](https://github.com/ember-animation/ember-animated/assets/142243/bd3a22fb-25f2-479b-9e35-70880c32b6d0)

### Before - motions section

![before1](https://github.com/ember-animation/ember-animated/assets/142243/28bad0e1-98a9-4b96-902a-8dceb64e703d)

### After - motions section

![after1](https://github.com/ember-animation/ember-animated/assets/142243/13dd928d-81ff-46fd-bbd3-0fa5a2ed4e90)
