### PR TITLE
Drop support for ember-element-helper <= 0.6.0

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -64,7 +64,7 @@
     "@embroider/addon-shim": "^1.8.7",
     "@embroider/macros": "^1.13.3",
     "assert-never": "^1.2.1",
-    "ember-element-helper": ">=0.5.0"
+    "ember-element-helper": ">=0.6.1"
   },
   "devDependencies": {
     "@babel/core": "^7.23.3",

--- a/addon/src/components/animated-container.hbs
+++ b/addon/src/components/animated-container.hbs
@@ -1,21 +1,9 @@
-{{#if this.useElementHelper}}
-  {{!--
-    The @class is only there to support a deprecated usage.
-  --}}
-  {{#let (element this.tag) as |Tag|~}}
-    {{! @glint-ignore: https://github.com/typed-ember/glint/issues/610 }}
-    <Tag class="animated-container {{@class}}" ...attributes>
-      {{yield}}
-    </Tag>
-  {{/let}}
-{{else}}
-  {{!--
-    The @class is only there to support a deprecated usage.
-  --}}
-  {{#let (component (-element this.tag) tagName=this.tag) as |Tag|~}}
-    {{! @glint-ignore: https://github.com/typed-ember/glint/issues/610 }}
-    <Tag class="animated-container {{@class}}" ...attributes>
-      {{yield}}
-    </Tag>
-  {{/let}}
-{{/if}}
+{{!--
+  The @class is only there to support a deprecated usage.
+--}}
+{{#let (element this.tag) as |Tag|~}}
+  {{! @glint-ignore: https://github.com/typed-ember/glint/issues/610 }}
+  <Tag class="animated-container {{@class}}" ...attributes>
+    {{yield}}
+  </Tag>
+{{/let}}

--- a/addon/src/components/animated-container.ts
+++ b/addon/src/components/animated-container.ts
@@ -2,7 +2,6 @@ import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { alias } from '@ember/object/computed';
 import { action } from '@ember/object';
-import { dependencySatisfies } from '@embroider/macros';
 import { Resize } from '../motions/resize.ts';
 import { task, type Task } from '../-private/ember-scheduler.ts';
 import Sprite from '../-private/sprite.ts';
@@ -226,8 +225,4 @@ export default class AnimatedContainerComponent<
     this.sprite = null;
   }).restartable()
   animate!: Task;
-
-  get useElementHelper(): boolean {
-    return dependencySatisfies('ember-element-helper', '>=0.6.1');
-  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
         specifier: ^1.2.1
         version: 1.2.1
       ember-element-helper:
-        specifier: '>=0.5.0'
+        specifier: '>=0.6.1'
         version: 0.8.5(@glint/environment-ember-loose@1.2.1)(@glint/template@1.2.1)
     devDependencies:
       '@babel/core':


### PR DESCRIPTION
This is a forced-hand solution to #594, and supercedes #647.

This drops support for `ember-element-helper` `<= 0.6.0` since there doesn't seem to be a good way to dynamically remove support for it during build time with ember macros at the moment. I've created an [issue]() in embroider, but I'm not sure how long it will take to have a solution.

`0.6.0` is almost two years old at this point, and continuing to support it in this library doesn't seem like it's worth it at this point. Happy to discuss!