### PR TITLE
Glint: make predicate Positional in animated-if and animated-value signatures

### DIFF
--- a/addon/src/components/animated-if.ts
+++ b/addon/src/components/animated-if.ts
@@ -4,7 +4,8 @@ import type { AnimatedEachSignature } from './animated-each.ts';
 
 interface AnimatedIfSignature<T> {
   Args: {
-    Named: AnimatedEachSignature<any>['Args']['Named'] & { predicate: T };
+    Positional: [T];
+    Named: AnimatedEachSignature<[T]>['Args']['Named'];
   };
   Blocks: {
     default: [];

--- a/addon/src/components/animated-value.ts
+++ b/addon/src/components/animated-value.ts
@@ -6,8 +6,8 @@ import type { AnimatedEachSignature } from './animated-each.ts';
 
 interface AnimatedValueSignature<T> {
   Args: {
-    Positional?: [T] | [];
-    Named: AnimatedEachSignature<T>['Args']['Named'] & { value?: T };
+    Positional: [T];
+    Named: AnimatedEachSignature<[T]>['Args']['Named'];
   };
   Blocks: {
     default: [T];


### PR DESCRIPTION
Follow up to [#613](https://github.com/ember-animation/ember-animated/pull/613#discussion_r1403147402)

`{{animated-if}}`, `{{animated-value}}`, `{{animated-value}}` are control flow expressions and not regular components as they expected to be used via curly braces.

We probably should implement custom curly component manager to enforce that, but that's separate.