### PR TITLE
Fix documentation code blocks

### DIFF
--- a/addon/src/components/animated-each.ts
+++ b/addon/src/components/animated-each.ts
@@ -66,6 +66,7 @@ export interface AnimatedEachSignature<T> {
 
 /**
   A drop in replacement for `{{#each}}` that animates changes to a list.
+
   ```hbs
   {{#animated-each items use=transition duration=2000 as |item|}}
     <div data-test-item={{item}} onclick={{action removeItem item}}>

--- a/addon/src/components/animated-if.ts
+++ b/addon/src/components/animated-if.ts
@@ -16,6 +16,7 @@ interface AnimatedIfSignature<T> {
 /**
   A drop in replacement for `{{#if}}` that animates changes when the predicate changes.
   Animated-if uses the same arguments as animated-each.
+
   ```hbs
   <button {{on 'click' this.toggleThing}}>Toggle</button>
 

--- a/addon/src/components/animated-orphans.ts
+++ b/addon/src/components/animated-orphans.ts
@@ -25,6 +25,7 @@ interface AnimatedOrphansSignature {
   A component that adopts any orphaned sprites so they can continue animating even
   after their original parent component has been destroyed. This relies on cloning
   DOM nodes, and the cloned nodes will be inserted as children of animated-orphans.
+
   ```hbs
   <AnimatedOrphans/>
   ```


### PR DESCRIPTION
This fixes the rendering of some code blocks, which currently [look like this](https://ember-animation.github.io/ember-animated/docs/api/components/animated-if):

<img width="788" alt="Ember Animated 2023-12-14 15-27-26" src="https://github.com/ember-animation/ember-animated/assets/43280/65fe4f86-845f-4d94-a5e7-c9663520cbff">

When I run this PR locally:

<img width="778" alt="Ember Animated 2023-12-14 15-29-10" src="https://github.com/ember-animation/ember-animated/assets/43280/e0693469-18ca-45c3-b119-4be6e288c0cf">

Thanks for all the work on this!