### PR TITLE
fix: Make it so that code examples render correctly v2.x/master

### DIFF
--- a/addon/src/components/animated-each.ts
+++ b/addon/src/components/animated-each.ts
@@ -74,6 +74,7 @@ export interface AnimatedEachSignature<T> {
     </div>
   {{/animated-each}}
   ```
+
   ```js
   import Component from '@ember/component';
   import move from 'ember-animated/motions/move';

--- a/addon/src/components/animated-if.ts
+++ b/addon/src/components/animated-if.ts
@@ -26,6 +26,7 @@ interface AnimatedIfSignature<T> {
     </div>
   {{/animated-if}}
   ```
+
   ```js
   import Component from '@glimmer/component';
   import move from 'ember-animated/motions/move';


### PR DESCRIPTION
- It seems like when there is no empty line before code example fencing, the markdown parser won't interpret the code block as code block.
- This is locally reproducible on v1.1.4 tag.
- Locally v2.0.0 works for me, but it broken in online version, but I figured this change could not hurt in both versions.

Relates to: #691 
Fixes: #689