### PR TITLE
Fix test-support exports

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -21,20 +21,21 @@
       "types": "./declarations/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./*": {
-      "types": "./declarations/*.d.ts",
-      "default": "./dist/*.js"
-    },
     "./test-support": {
       "types": "./declarations/test-support/index.d.ts",
       "default": "./dist/test-support/index.js"
+    },
+    "./*": {
+      "types": "./declarations/*.d.ts",
+      "default": "./dist/*.js"
     },
     "./addon-main.js": "./addon-main.cjs"
   },
   "typesVersions": {
     "*": {
       "*": [
-        "declarations/*"
+        "declarations/*",
+        "declarations/*/index"
       ]
     }
   },


### PR DESCRIPTION
This is fixing imports of `ember-animated/test-support` not resolving correctly. Order in `package.json#exports`  is relevant, so the catch-all rule should come last. Also, for TS projects still using legacy `moduleResolution`, `typesVersions` should cover the index-module.