### PR TITLE
Widen peer range for peer, @ember/test-helpers

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -117,7 +117,7 @@
     "typescript": "^5.3.3"
   },
   "peerDependencies": {
-    "@ember/test-helpers": "^2.6.0 || ^3.0.0"
+    "@ember/test-helpers": "^2.6.0 || ^3.0.0 || >= 4.0.0"
   },
   "peerDependenciesMeta": {
     "@ember/test-helpers": {


### PR DESCRIPTION
Should allow usage of `@ember/test-helpers` @ v4