### PR TITLE
Get ember service in way that avoids deprecation

### DIFF
--- a/addon/src/components/animated-beacon.ts
+++ b/addon/src/components/animated-beacon.ts
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import * as emberService from "@ember/service";
+import * as emberService from '@ember/service';
 import { task, type Task } from '../-private/ember-scheduler.ts';
 import { afterRender, microwait } from '../-private/concurrency-helpers.ts';
 import { componentNodes } from '../-private/ember-internals.ts';

--- a/addon/src/components/animated-container.ts
+++ b/addon/src/components/animated-container.ts
@@ -1,4 +1,4 @@
-import * as emberService from "@ember/service";
+import * as emberService from '@ember/service';
 import Component from '@ember/component';
 import { alias } from '@ember/object/computed';
 import { action } from '@ember/object';

--- a/addon/src/components/animated-each.ts
+++ b/addon/src/components/animated-each.ts
@@ -1,6 +1,6 @@
 import { alias } from '@ember/object/computed';
 import { computed, get, action } from '@ember/object';
-import * as emberService from "@ember/service";
+import * as emberService from '@ember/service';
 import Component from '@ember/component';
 import assertNever from 'assert-never';
 import { task, type Task } from '../-private/ember-scheduler.ts';

--- a/addon/src/components/animated-orphans.ts
+++ b/addon/src/components/animated-orphans.ts
@@ -1,4 +1,4 @@
-import * as emberService from "@ember/service";
+import * as emberService from '@ember/service';
 import { action } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import Component from '@ember/component';


### PR DESCRIPTION
Closes #783 

Uses code suggested by deprecation block https://deprecations.emberjs.com/id/importing-inject-from-ember-service/