### PR TITLE
Modify ember try command to skip cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run Tests
-        run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}
+        run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }} --skip-cleanup
         working-directory: test-app
 
   typescript-compatibility:


### PR DESCRIPTION
Added --skip-cleanup option to ember try command.



We don't need to cleanup in CI -- this should help CI finish sooner, as well as use less electricity/water